### PR TITLE
feat(templates): add reusable pagination partial for list views

### DIFF
--- a/templates/partials/_pagination.html
+++ b/templates/partials/_pagination.html
@@ -1,0 +1,51 @@
+# path: templates/partials/_pagination.html
+{% load querystring %}
+<div class="pagination-shell" data-testid="pagination-shell">
+  <div class="pagination-count">{{ pagination.count_line }}</div>
+
+  {% if pagination.page_obj.paginator.num_pages > 1 %}
+    <nav aria-label="Pagination">
+      <ul class="pagination pagination-sm mb-0">
+        <li class="page-item {% if not pagination.page_obj.has_previous %}disabled{% endif %}">
+          <a
+            class="page-link"
+            href="?{% replace_query page=1 %}"
+            aria-label="First page"
+          >First</a>
+        </li>
+        <li class="page-item {% if not pagination.page_obj.has_previous %}disabled{% endif %}">
+          <a
+            class="page-link"
+            href="?{% replace_query page=pagination.page_obj.previous_page_number|default:1 %}"
+            aria-label="Previous page"
+          >Previous</a>
+        </li>
+
+        {% for page_number in pagination.page_numbers %}
+          <li class="page-item {% if page_number == pagination.page_obj.number %}active{% endif %}">
+            <a
+              class="page-link"
+              href="?{% replace_query page=page_number %}"
+              aria-current="{% if page_number == pagination.page_obj.number %}page{% else %}false{% endif %}"
+            >{{ page_number }}</a>
+          </li>
+        {% endfor %}
+
+        <li class="page-item {% if not pagination.page_obj.has_next %}disabled{% endif %}">
+          <a
+            class="page-link"
+            href="?{% replace_query page=pagination.page_obj.next_page_number|default:pagination.page_obj.paginator.num_pages %}"
+            aria-label="Next page"
+          >Next</a>
+        </li>
+        <li class="page-item {% if not pagination.page_obj.has_next %}disabled{% endif %}">
+          <a
+            class="page-link"
+            href="?{% replace_query page=pagination.page_obj.paginator.num_pages %}"
+            aria-label="Last page"
+          >Last</a>
+        </li>
+      </ul>
+    </nav>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
Adds a shared pagination partial to standardise pagination UI and behaviour across list-based templates.

## What Changed
- Added reusable template partial:
  - `templates/partials/_pagination.html`
- Encapsulated common pagination rendering concerns:
  - page navigation controls
  - current/neighbor page links
  - consistent layout and labels for paginated surfaces
- Designed for integration with shared pagination/querystring utilities so links preserve active filters/search params.

## Why
Removes duplicated pagination markup, keeps pagination UX consistent across pages, and reduces maintenance overhead when pagination UI needs updates.

## Impact
- No database or migration changes.
- Template-only enhancement; existing list pages can adopt incrementally.
- Improves consistency for navigation on paginated screens.

## Validation
- Lint/format and test suite checks pass.
- Compatible with current pagination contract used by views/templates.