### PR TITLE
Chore/add public page smoke tests

### DIFF
--- a/tests/test_public_views.py
+++ b/tests/test_public_views.py
@@ -1,5 +1,6 @@
 # path: tests/test_public_views.py
 """Smoke tests for public-facing pages."""
+
 import pytest
 from django.urls import reverse
 
@@ -11,11 +12,12 @@ def test_landing_page_renders_role_entry_buttons(client) -> None:
     assert response.status_code == 200
     body = response.content.decode()
 
-    assert "One clear place to triage returns, evidence, and follow-up." in body
+    assert "Resolve return cases faster with one operational system of record." in body
     assert reverse("admin-login") in body
     assert reverse("ops-login") in body
     assert reverse("customer-login") in body
     assert reverse("merchant-login") in body
+
 
 @pytest.mark.parametrize(
     ("route_name", "expected_text"),


### PR DESCRIPTION
## Summary
Adds smoke-test coverage for the public landing page and role-specific surface entry pages so the public UI contract is checked explicitly.

## What Changed
- Added `tests/test_public_views.py`:
  - verifies the landing page renders successfully
  - verifies the landing page includes links to all public role entry routes:
    - admin
    - ops
    - customer
    - merchant
  - adds parameterized coverage for each public surface entry page
  - asserts each surface entry route returns `200`
  - asserts each surface entry page renders its expected role-specific explanatory copy
- Updated the landing-page assertion to match the current hero messaging:
  - checks for `Resolve return cases faster with one operational system of record.`
- Formatted the new test file so style checks pass cleanly

## Why
Adds lightweight protection around the new public-facing UI:
- ensures the landing page continues to expose the expected role-entry routes
- ensures each public workspace entry page renders the correct copy
- reduces the risk of regressions in routing or public template content as the UI evolves

## Impact
- Test-only PR; no app logic changes.
- Improves confidence in the public landing and workspace entry experience.

## Validation
- `docker compose exec web python -m black . --check`
- `docker compose exec web python -m ruff check .`
- `docker compose exec web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80`