### PR TITLE
chore(repo): ignore shell scripts and exclude CSS from Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,4 @@ coverage.xml -diff
 Makefile linguist-detectable=false
 Dockerfile linguist-detectable=false
 *.html linguist-detectable=false
+*.css linguist-detectable=false

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ coverage.xml
 .DS_Store
 .vscode/
 .idea/
+
+# Shell scripts
+*.sh


### PR DESCRIPTION
## Summary
Updates repository metadata so local shell scripts are not tracked and GitHub Linguist no longer counts CSS toward the language breakdown.

## Changes
- add `*.sh` to `.gitignore`
- add `*.css linguist-detectable=false` to `.gitattributes`

## Why
Local runbook and utility shell scripts are environment-specific and should not appear as untracked repo changes. Excluding CSS from Linguist also keeps the GitHub language bar focused on the project’s primary implementation language.

## Expected Outcome
- shell scripts are ignored by Git
- GitHub Linguist recalculates the repo language distribution and stops counting CSS
- Python becomes the effective dominant language shown for the repository