### PR TITLE
chore(ml): update baseline model metadata artifact

### DIFF
--- a/ml_artifacts/baseline-logreg-v1-seed-7-rows-500.json
+++ b/ml_artifacts/baseline-logreg-v1-seed-7-rows-500.json
@@ -7,7 +7,7 @@
   },
   "model_version": "baseline-logreg-v1-seed-7-rows-500",
   "reason_code_schema_version": "return-risk-reasons-sprint2-v1",
-  "trained_at": "2026-03-26T17:21:47.974612+00:00",
+  "trained_at": "2026-03-30T09:39:35.848215+00:00",
   "training_rows": 500,
   "training_seed": 7
 }


### PR DESCRIPTION
## Summary
This PR updates the committed baseline model metadata artifact for the active escalation-risk model.

## Changes
- refreshed [baseline-logreg-v1-seed-7-rows-500.json](/Users/adrianadewunmi/VSCODE/Returns-Escalation-Predictor-Project/ml_artifacts/baseline-logreg-v1-seed-7-rows-500.json)
- kept the artifact aligned with the currently trained and registered baseline model
- preserved the expected metadata contract used by the model registry and scoring flow

## Verification
- `docker compose exec web python manage.py train_escalation_model --seed 7 --size 500`

## Expected metadata
- `model_version`: `baseline-logreg-v1-seed-7-rows-500`
- `training_rows`: `500`
- `training_seed`: `7`

## Notes
- this PR updates metadata only; it does not introduce a new model interface or API contract