### PR TITLE
Feat/test ops queue pagination contract

### DIFF
--- a/tests/test_ops_queue.py
+++ b/tests/test_ops_queue.py
@@ -1,25 +1,35 @@
-# path: returns/test_ops_queue.py
-"""Integration tests for the ops queue surface."""
+"""Integration tests for the standalone ops queue route."""
+
+from __future__ import annotations
 
 import pytest
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from tests.factories.accounts import UserFactory
-from tests.factories.returns import CustomerProfileFactory, MerchantProfileFactory, ReturnCaseFactory
+from tests.factories import ReturnCaseFactory, RiskScoreFactory, UserFactory
 
 
-def _add_group(user, name: str) -> None:
-    """Attach a user to a named Django group."""
-    group, _ = Group.objects.get_or_create(name=name)
+def add_group(user, group_name: str) -> None:
+    """Attach a Django group to a user for test setup."""
+
+    group, _ = Group.objects.get_or_create(name=group_name)
     user.groups.add(group)
 
 
-@pytest.mark.django_db()
-def test_ops_queue_requires_ops_role(client):
-    """Authenticated non-ops users should receive a clean 403 page."""
+def ops_user() -> UserFactory:
+    """Create a user with ops access."""
+
     user = UserFactory()
-    _add_group(user, "customer")
+    add_group(user, "Ops")
+    return user
+
+
+@pytest.mark.django_db
+def test_ops_queue_requires_ops_role(client) -> None:
+    """Authenticated non-ops users should receive a clean 403 page."""
+
+    user = UserFactory()
+    add_group(user, "Customer")
     client.force_login(user)
 
     response = client.get(reverse("ops:queue"))
@@ -28,126 +38,106 @@ def test_ops_queue_requires_ops_role(client):
     assert "Forbidden" in response.content.decode()
 
 
-@pytest.mark.django_db()
-def test_ops_queue_uses_fixed_page_size_and_count_line(client):
-    """The queue should paginate at 15 and expose the expected count line."""
-    ops_user = UserFactory()
-    _add_group(ops_user, "ops")
-    client.force_login(ops_user)
+@pytest.mark.django_db
+def test_ops_queue_uses_fixed_page_size_and_pagination_context(client) -> None:
+    """The /ops/ queue should paginate at 15 and expose the shared count line."""
 
-    customer = CustomerProfileFactory()
-    merchant = MerchantProfileFactory()
+    client.force_login(ops_user())
 
     for index in range(17):
         ReturnCaseFactory(
-            reference=f"RC-{index:04d}",
-            customer=customer,
-            merchant=merchant,
-            priority="normal",
+            order_reference=f"OPS-{index:04d}",
+            priority="medium",
             status="submitted",
         )
 
     response = client.get(reverse("ops:queue"))
 
     assert response.status_code == 200
-    assert response.context["page_obj"].number == 1
-    assert len(response.context["page_obj"].object_list) == 15
-    assert response.context["count_line"] == "Showing 1-15 of 17"
+    assert response.context["pagination"].page_obj.number == 1
+    assert len(response.context["pagination"].page_obj.object_list) == 15
+    assert response.context["pagination"].count_line == "Showing 1-15 of 17"
 
 
-@pytest.mark.django_db()
-def test_ops_queue_invalid_page_falls_back_to_first_page(client):
+@pytest.mark.django_db
+def test_ops_queue_invalid_page_falls_back_to_first_page(client) -> None:
     """A non-integer page value should resolve to page one."""
-    ops_user = UserFactory()
-    _add_group(ops_user, "ops")
-    client.force_login(ops_user)
 
-    customer = CustomerProfileFactory()
-    merchant = MerchantProfileFactory()
+    client.force_login(ops_user())
 
     for index in range(16):
-        ReturnCaseFactory(
-            reference=f"RC-A-{index:04d}",
-            customer=customer,
-            merchant=merchant,
-        )
+        ReturnCaseFactory(order_reference=f"OPS-A-{index:04d}")
 
     response = client.get(reverse("ops:queue"), {"page": "abc"})
 
     assert response.status_code == 200
-    assert response.context["page_obj"].number == 1
+    assert response.context["pagination"].page_obj.number == 1
 
 
-@pytest.mark.django_db()
-def test_ops_queue_page_zero_falls_back_to_first_page(client):
+@pytest.mark.django_db
+def test_ops_queue_page_zero_falls_back_to_first_page(client) -> None:
     """A page number of zero should resolve to page one."""
-    ops_user = UserFactory()
-    _add_group(ops_user, "ops")
-    client.force_login(ops_user)
 
-    customer = CustomerProfileFactory()
-    merchant = MerchantProfileFactory()
+    client.force_login(ops_user())
 
     for index in range(16):
-        ReturnCaseFactory(
-            reference=f"RC-Z-{index:04d}",
-            customer=customer,
-            merchant=merchant,
-        )
+        ReturnCaseFactory(order_reference=f"OPS-Z-{index:04d}")
 
     response = client.get(reverse("ops:queue"), {"page": "0"})
 
     assert response.status_code == 200
-    assert response.context["page_obj"].number == 1
+    assert response.context["pagination"].page_obj.number == 1
 
 
-@pytest.mark.django_db()
-def test_ops_queue_out_of_range_page_returns_last_page(client):
+@pytest.mark.django_db
+def test_ops_queue_out_of_range_page_returns_last_page(client) -> None:
     """An out-of-range page should resolve to the final available page."""
-    ops_user = UserFactory()
-    _add_group(ops_user, "ops")
-    client.force_login(ops_user)
 
-    customer = CustomerProfileFactory()
-    merchant = MerchantProfileFactory()
+    client.force_login(ops_user())
 
     for index in range(31):
-        ReturnCaseFactory(
-            reference=f"RC-L-{index:04d}",
-            customer=customer,
-            merchant=merchant,
-        )
+        ReturnCaseFactory(order_reference=f"OPS-L-{index:04d}")
 
     response = client.get(reverse("ops:queue"), {"page": "999"})
 
     assert response.status_code == 200
-    assert response.context["page_obj"].number == 3
-    assert len(response.context["page_obj"].object_list) == 1
+    assert response.context["pagination"].page_obj.number == 3
+    assert len(response.context["pagination"].page_obj.object_list) == 1
 
 
-@pytest.mark.django_db()
-def test_ops_queue_preserves_filters_in_query_string(client):
-    """Pagination links should preserve active filters."""
-    ops_user = UserFactory()
-    _add_group(ops_user, "ops")
-    client.force_login(ops_user)
+@pytest.mark.django_db
+def test_ops_queue_exposes_queue_filters_and_preserves_query_params(client) -> None:
+    """The standalone queue should expose active filters and preserve them in pagination."""
 
-    customer = CustomerProfileFactory()
-    merchant = MerchantProfileFactory()
+    client.force_login(ops_user())
 
     for index in range(18):
-        ReturnCaseFactory(
-            reference=f"RC-F-{index:04d}",
-            customer=customer,
-            merchant=merchant,
-            status="awaiting_customer",
+        case = ReturnCaseFactory(
+            order_reference=f"OPS-F-{index:04d}",
+            status="waiting_customer",
             priority="high",
         )
+        RiskScoreFactory(case=case, label="high")
+
+    ReturnCaseFactory(order_reference="OPS-OTHER-1", status="submitted", priority="low")
 
     response = client.get(
         reverse("ops:queue"),
-        {"status": "awaiting_customer", "priority": "high"},
+        {
+            "status": "waiting_customer",
+            "priority": "high",
+            "risk_label": "high",
+            "page": 2,
+        },
     )
 
+    body = response.content.decode()
+
     assert response.status_code == 200
-    assert response.context["query_string"] == "status=awaiting_customer&priority=high"
+    assert response.context["queue_filters"].status == "waiting_customer"
+    assert response.context["queue_filters"].priority == "high"
+    assert response.context["queue_filters"].risk_label == "high"
+    assert response.context["pagination"].page_obj.number == 2
+    assert "status=waiting_customer" in body
+    assert "priority=high" in body
+    assert "risk_label=high" in body


### PR DESCRIPTION
## Summary
Adds focused integration coverage for the standalone `/ops/` queue route using the live ReturnHub queue contract.

## Changes
- rewrites `tests/test_ops_queue.py` against the live `/ops/` route
- updates the test file to use the current `tests.factories` module layout
- aligns test data with the current `ReturnCase` schema using fields such as `order_reference`
- aligns status and priority values with the current project enums
- asserts against the shared `pagination` context instead of the stale standalone queue context
- verifies fixed page size, count-line output, invalid page fallback, zero-page fallback, and out-of-range page fallback
- verifies the route exposes `queue_filters` and preserves active filter query parameters in rendered output

## Why
The previous `tests/test_ops_queue.py` file was shaped around an older queue implementation with stale import paths, field names, enum values, and context keys. This PR brings the test coverage onto the live `/ops/` route so pagination and filter behavior are validated against the current project structure.

## Validation
- `docker compose exec web pytest tests/test_ops_queue.py -q`

## Result
- the standalone `/ops/` queue route now has focused pagination-contract coverage
- tests reflect the current `ReturnCase` schema and queue context
- stale queue test assumptions have been removed
- focused `/ops/` queue tests pass