### PR TITLE
Feat/add ops specific presentation layer

### DIFF
--- a/console/views.py
+++ b/console/views.py
@@ -192,6 +192,11 @@ class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
                 context,
                 request=self.request,
             ),
+            "notes_panel_html": render_to_string(
+                "ops/partials/_notes_panel.html",
+                context,
+                request=self.request,
+            ),
             "timeline_html": render_to_string(
                 "ops/partials/_timeline.html",
                 context,
@@ -236,6 +241,7 @@ class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
             "upload_success_message": "",
             "ops_queue_url": reverse("ops:queue"),
             "ops_action_success_message": "",
+            "note_success_message": "",
             "latest_request_event": latest_request_event,
         }
 
@@ -264,6 +270,7 @@ class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
         )
 
         success_message = ""
+        note_success_message = ""
         status_code = 200
 
         try:
@@ -298,7 +305,7 @@ class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
                         case=return_case,
                         body=form.cleaned_data["body"],
                     )
-                    success_message = "Internal note added."
+                    note_success_message = "Internal note added."
                 else:
                     status_code = 400
             else:
@@ -321,6 +328,7 @@ class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
         else:
             context.update(forms)
         context["ops_action_success_message"] = success_message
+        context["note_success_message"] = note_success_message
 
         if request.headers.get("X-Requested-With") == "XMLHttpRequest":
             return self._render_action_response(context=context, status_code=status_code)

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -493,6 +493,56 @@ button:focus-visible {
   margin-bottom: calc(var(--rh-space-4) + 0.4rem);
 }
 
+.rh-fragment-panel {
+  position: relative;
+}
+
+.rh-fragment-panel__content {
+  transition: opacity 180ms ease, filter 180ms ease;
+}
+
+.rh-fragment-panel__status {
+  position: absolute;
+  top: 0.85rem;
+  right: 1rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 252, 247, 0.96);
+  border: 1px solid rgba(27, 35, 28, 0.1);
+  box-shadow: var(--rh-shadow-sm);
+  color: var(--rh-color-text-muted);
+  font-size: var(--rh-font-size-xs);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.rh-fragment-panel__status::before {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  border: 2px solid rgba(31, 90, 67, 0.22);
+  border-top-color: var(--rh-color-accent-strong);
+  animation: rh-fragment-spin 0.9s linear infinite;
+}
+
+.rh-fragment-panel.is-loading .rh-fragment-panel__content {
+  opacity: 0.42;
+  filter: saturate(0.72);
+  pointer-events: none;
+}
+
+@keyframes rh-fragment-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .rh-section-heading h2 {
   font-family: var(--rh-font-family-display);
   font-size: clamp(1.8rem, 2.6vw, 2.5rem);

--- a/templates/ops/case_detail.html
+++ b/templates/ops/case_detail.html
@@ -17,37 +17,61 @@
       <a class="btn btn-outline-secondary rh-btn-secondary" href="{{ ops_queue_url }}">Back to ops queue</a>
     </div>
 
-    <div id="case-header">
-      {% include "ops/partials/_case_header.html" %}
+    <div id="case-header" class="rh-fragment-panel" data-loading-label="Updating case header" aria-busy="false">
+      <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+      <div class="rh-fragment-panel__content">
+        {% include "ops/partials/_case_header.html" %}
+      </div>
     </div>
 
     {% include "ops/partials/_case_action_bar.html" %}
 
     <div class="row g-4">
       <div class="col-12 col-xl-8">
-        <div id="case-status-panel">
-          {% include "ops/partials/_status_panel.html" %}
+        <div id="case-status-panel" class="rh-fragment-panel" data-loading-label="Updating workflow state" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "ops/partials/_status_panel.html" %}
+          </div>
         </div>
-        <div class="mb-4" id="case-notes-panel">
-          {% include "ops/partials/_notes_panel.html" %}
+        <div id="case-notes-panel" class="rh-fragment-panel mb-4" data-loading-label="Updating internal notes" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "ops/partials/_notes_panel.html" %}
+          </div>
         </div>
-        <div id="case-document-table">
-          {% include "ops/partials/_evidence_list.html" %}
+        <div id="case-document-table" class="rh-fragment-panel" data-loading-label="Updating case documents" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "ops/partials/_evidence_list.html" %}
+          </div>
         </div>
-        <div id="case-timeline">
-          {% include "ops/partials/_timeline.html" %}
+        <div id="case-timeline" class="rh-fragment-panel" data-loading-label="Updating audit timeline" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "ops/partials/_timeline.html" %}
+          </div>
         </div>
       </div>
 
       <div class="col-12 col-xl-4">
-        <div class="mb-4" id="case-risk-panel">
-          {% include "ops/partials/_risk_panel.html" %}
+        <div id="case-risk-panel" class="rh-fragment-panel mb-4" data-loading-label="Updating risk summary" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "ops/partials/_risk_panel.html" %}
+          </div>
         </div>
-        <div class="mb-4" id="case-action-panel">
-          {% include "ops/partials/_action_panel.html" %}
+        <div id="case-action-panel" class="rh-fragment-panel mb-4" data-loading-label="Updating case actions" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "ops/partials/_action_panel.html" %}
+          </div>
         </div>
-        <div id="case-upload-panel">
-          {% include "partials/_upload_panel.html" with upload_form=upload_form upload_success_message=upload_success_message return_case=return_case actor_role=actor_role %}
+        <div id="case-upload-panel" class="rh-fragment-panel" data-loading-label="Updating upload panel" aria-busy="false">
+          <div class="rh-fragment-panel__status visually-hidden" aria-live="polite" aria-atomic="true"></div>
+          <div class="rh-fragment-panel__content">
+            {% include "partials/_upload_panel.html" with upload_form=upload_form upload_success_message=upload_success_message return_case=return_case actor_role=actor_role %}
+          </div>
         </div>
       </div>
     </div>
@@ -55,35 +79,58 @@
 
   <script>
     (() => {
-      async function submitCaseUpload(form) {
-        const response = await fetch(form.action, {
-          method: "POST",
-          body: new FormData(form),
-          headers: { "X-Requested-With": "XMLHttpRequest" },
-          credentials: "same-origin",
-        });
+      function setFragmentLoading(element, isLoading) {
+        if (!element) {
+          return;
+        }
 
-        const payload = await response.json();
+        const status = element.querySelector(".rh-fragment-panel__status");
+        const label = element.dataset.loadingLabel || "Updating section";
+
+        element.setAttribute("aria-busy", isLoading ? "true" : "false");
+        element.classList.toggle("is-loading", isLoading);
+
+        if (status) {
+          status.textContent = isLoading ? label : "";
+          status.classList.toggle("visually-hidden", !isLoading);
+        }
+      }
+
+      function updateFragment(selector, html) {
+        const element = document.querySelector(selector);
+        const content = element?.querySelector(".rh-fragment-panel__content");
+
+        if (content && html) {
+          content.innerHTML = html;
+        }
+      }
+
+      async function submitCaseUpload(form) {
         const uploadPanel = document.querySelector("#case-upload-panel");
         const documentTable = document.querySelector("#case-document-table");
 
-        if (uploadPanel && payload.upload_panel_html) {
-          uploadPanel.innerHTML = payload.upload_panel_html;
-        }
-        if (documentTable && payload.document_table_html) {
-          documentTable.innerHTML = payload.document_table_html;
+        setFragmentLoading(uploadPanel, true);
+        setFragmentLoading(documentTable, true);
+
+        try {
+          const response = await fetch(form.action, {
+            method: "POST",
+            body: new FormData(form),
+            headers: { "X-Requested-With": "XMLHttpRequest" },
+            credentials: "same-origin",
+          });
+
+          const payload = await response.json();
+
+          updateFragment("#case-upload-panel", payload.upload_panel_html);
+          updateFragment("#case-document-table", payload.document_table_html);
+        } finally {
+          setFragmentLoading(uploadPanel, false);
+          setFragmentLoading(documentTable, false);
         }
       }
 
       async function submitOpsAction(form) {
-        const response = await fetch(form.action, {
-          method: "POST",
-          body: new FormData(form),
-          headers: { "X-Requested-With": "XMLHttpRequest" },
-          credentials: "same-origin",
-        });
-
-        const payload = await response.json();
         const fragmentTargets = [
           ["#case-header", "case_header_html"],
           ["#case-status-panel", "status_panel_html"],
@@ -93,12 +140,28 @@
           ["#case-action-panel", "action_panel_html"],
         ];
 
-        fragmentTargets.forEach(([selector, key]) => {
-          const element = document.querySelector(selector);
-          if (element && payload[key]) {
-            element.innerHTML = payload[key];
-          }
+        fragmentTargets.forEach(([selector]) => {
+          setFragmentLoading(document.querySelector(selector), true);
         });
+
+        try {
+          const response = await fetch(form.action, {
+            method: "POST",
+            body: new FormData(form),
+            headers: { "X-Requested-With": "XMLHttpRequest" },
+            credentials: "same-origin",
+          });
+
+          const payload = await response.json();
+
+          fragmentTargets.forEach(([selector, key]) => {
+            updateFragment(selector, payload[key]);
+          });
+        } finally {
+          fragmentTargets.forEach(([selector]) => {
+            setFragmentLoading(document.querySelector(selector), false);
+          });
+        }
       }
 
       document.addEventListener("submit", (event) => {

--- a/templates/ops/case_detail.html
+++ b/templates/ops/case_detail.html
@@ -28,6 +28,9 @@
         <div id="case-status-panel">
           {% include "ops/partials/_status_panel.html" %}
         </div>
+        <div class="mb-4" id="case-notes-panel">
+          {% include "ops/partials/_notes_panel.html" %}
+        </div>
         <div id="case-document-table">
           {% include "ops/partials/_evidence_list.html" %}
         </div>
@@ -84,6 +87,7 @@
         const fragmentTargets = [
           ["#case-header", "case_header_html"],
           ["#case-status-panel", "status_panel_html"],
+          ["#case-notes-panel", "notes_panel_html"],
           ["#case-timeline", "timeline_html"],
           ["#case-risk-panel", "risk_panel_html"],
           ["#case-action-panel", "action_panel_html"],

--- a/templates/ops/partials/_action_panel.html
+++ b/templates/ops/partials/_action_panel.html
@@ -11,6 +11,5 @@
 
   <div class="d-grid gap-4">
     {% include "ops/partials/_request_info_panel.html" %}
-    {% include "ops/partials/_notes_panel.html" %}
   </div>
 </section>

--- a/templates/ops/partials/_case_action_bar.html
+++ b/templates/ops/partials/_case_action_bar.html
@@ -2,11 +2,12 @@
 <section class="rh-card mb-4" aria-label="Case section navigation">
   <div class="rh-section-heading mb-3">
     <div class="rh-kicker">Quick navigation</div>
-    <h2>Jump between workflow, documents, timeline, and case actions.</h2>
+    <h2>Jump between workflow, notes, documents, timeline, and case actions.</h2>
   </div>
 
   <div class="d-flex flex-wrap gap-2">
     <a href="#case-status-panel" class="btn btn-dark btn-sm">Workflow state</a>
+    <a href="#case-notes-panel" class="btn btn-outline-secondary rh-btn-secondary btn-sm">Internal notes</a>
     <a href="#case-document-table" class="btn btn-outline-secondary rh-btn-secondary btn-sm">Documents</a>
     <a href="#case-timeline" class="btn btn-outline-secondary rh-btn-secondary btn-sm">Timeline</a>
     <a href="#case-action-panel" class="btn btn-outline-secondary rh-btn-secondary btn-sm">Case actions</a>

--- a/templates/ops/partials/_evidence_list.html
+++ b/templates/ops/partials/_evidence_list.html
@@ -2,7 +2,39 @@
 <section class="rh-card mb-4" aria-label="Case documents">
   <div class="rh-section-heading mb-3">
     <div class="rh-kicker">Documents</div>
-    <h2>Evidence, responses, and internal attachments for this case.</h2>
+    <h2>Evidence, responses, and internal attachments already linked to this case.</h2>
   </div>
-  {% include "partials/_document_table.html" with documents=documents %}
+
+  {% if documents %}
+    <div class="d-grid gap-3">
+      {% for document in documents %}
+        <article class="rh-visual-panel rh-visual-panel--case">
+          <div class="d-flex flex-column flex-md-row justify-content-between gap-3">
+            <div>
+              <p class="fw-semibold mb-1">{{ document.original_filename }}</p>
+              <p class="text-muted small mb-1">
+                {{ document.get_kind_display }} · Added {{ document.created_at|date:"j M Y, H:i" }}
+              </p>
+              {% if document.notes %}
+                <p class="mb-0 text-muted">{{ document.notes }}</p>
+              {% endif %}
+            </div>
+
+            <div class="d-flex flex-column align-items-md-end gap-2">
+              <span class="rh-status-pill rh-status-pill--neutral">
+                {{ document.content_type }}
+              </span>
+              {% if document.file %}
+                <a href="{{ document.file.url }}" class="btn btn-outline-secondary rh-btn-secondary btn-sm">
+                  Open file
+                </a>
+              {% endif %}
+            </div>
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% include "partials/_empty_state.html" with title="No documents yet" body="Evidence uploaded by customers, merchants, or ops will appear here in created order." %}
+  {% endif %}
 </section>

--- a/templates/ops/partials/_notes_panel.html
+++ b/templates/ops/partials/_notes_panel.html
@@ -7,6 +7,12 @@
     </p>
   </div>
 
+  {% if note_success_message %}
+    <div class="alert alert-success" role="status">
+      {{ note_success_message }}
+    </div>
+  {% endif %}
+
   {% include "ops/partials/_note_form.html" %}
   {% include "ops/partials/_note_list.html" %}
 </section>

--- a/templates/ops/partials/_timeline.html
+++ b/templates/ops/partials/_timeline.html
@@ -2,7 +2,34 @@
 <section class="rh-card" aria-label="Audit timeline">
   <div class="rh-section-heading mb-3">
     <div class="rh-kicker">Timeline</div>
-    <h2>Append-only workflow history for the current case.</h2>
+    <h2>Append-only workflow history for this case.</h2>
   </div>
-  {% include "partials/_timeline.html" with events=events %}
+
+  {% if events %}
+    <div class="d-grid gap-3">
+      {% for event in events %}
+        <article class="rh-visual-panel rh-visual-panel--case">
+          <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-2">
+            <div>
+              <p class="fw-semibold mb-1">{{ event.event_type|title }}</p>
+              <p class="text-muted small mb-0">{{ event.created_at|date:"j M Y, H:i" }}</p>
+            </div>
+            <div class="text-md-end text-muted small">
+              {% if event.actor %}
+                {{ event.actor.get_full_name|default:event.actor.email }}
+              {% else %}
+                System
+              {% endif %}
+            </div>
+          </div>
+
+          {% if event.payload %}
+            <pre class="mb-0 small">{{ event.payload|pprint }}</pre>
+          {% endif %}
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% include "partials/_empty_state.html" with title="No timeline events yet" body="Case creation, uploads, status changes, and risk scoring will appear here." %}
+  {% endif %}
 </section>

--- a/templates/ops/queue.html
+++ b/templates/ops/queue.html
@@ -1,17 +1,17 @@
 <!-- path: templates/ops/queue.html -->
 {% extends "base.html" %}
 
-{% block title %}Ops Queue | ReturnHub{% endblock %}
+{% block title %}Ops queue | ReturnHub{% endblock %}
 {% block page_title %}<span class="rh-page-title">Ops Queue</span>{% endblock %}
 
 {% block content %}
-  <section class="rh-band rh-band--workflow mb-4">
+  <section class="rh-band rh-band--workflow mb-4 py-4">
     <div class="rh-section-heading">
-      <div class="rh-kicker">Operations queue</div>
-      <h2>Review return cases in the shared ReturnHub shell.</h2>
+      <div class="rh-kicker">Ops workspace</div>
+      <h2>Returns queue</h2>
       <p>
-        Filters, summary counts, pagination, and the current risk signal stay aligned with the
-        live queue contract already used across the product.
+        Review cases in a stable operational order, filter by workflow state, and move directly
+        into case detail.
       </p>
     </div>
   </section>

--- a/tests/test_console_shell.py
+++ b/tests/test_console_shell.py
@@ -52,7 +52,8 @@ def test_ops_route_renders_standalone_queue_page_for_ops_user(client) -> None:
     body = response.content.decode()
     assert response.status_code == 200
     assert "Ops Queue" in body
-    assert "Operations queue" in body
+    assert "Ops workspace" in body
+    assert "Returns queue" in body
     assert 'id="ops-queue-table"' in body
 
 
@@ -71,7 +72,7 @@ def test_ops_route_returns_queue_table_partial_for_htmx_request(client) -> None:
     assert response.status_code == 200
     assert "Return cases" in body
     assert "OPS-HTMX-1" in body
-    assert "Operations queue" not in body
+    assert "Ops workspace" not in body
 
 
 @pytest.mark.django_db

--- a/tests/test_ops_case_detail.py
+++ b/tests/test_ops_case_detail.py
@@ -51,11 +51,17 @@ def test_ops_case_detail_renders_documents_timeline_and_risk(client) -> None:
     assert "Escalation risk" in content
     assert "Timeline" in content
     assert "Quick navigation" in content
+    assert "Jump between workflow, notes, documents, timeline, and case actions." in content
     assert "Operational workflow controls" in content
     assert "Apply status update" in content
     assert "Request information" in content
     assert "Save internal note" in content
     assert "Internal notes" in content
+    assert (
+        content.index("Workflow state")
+        < content.index("Internal notes")
+        < content.index("Documents")
+    )
 
 
 @pytest.mark.django_db
@@ -171,6 +177,7 @@ def test_ops_case_detail_status_update_post_refreshes_inline_fragments(client, m
     assert "Case status updated." in payload["action_panel_html"]
     assert "In review" in payload["status_panel_html"]
     assert "High" in payload["status_panel_html"]
+    assert "Internal notes" in payload["notes_panel_html"]
 
 
 @pytest.mark.django_db
@@ -211,6 +218,7 @@ def test_ops_case_detail_request_info_post_moves_case_to_waiting_state(client, m
     assert "Case moved to waiting on customer." in payload["action_panel_html"]
     assert "Waiting for customer" in payload["status_panel_html"]
     assert "Latest request" in payload["action_panel_html"]
+    assert "Internal notes" in payload["notes_panel_html"]
 
 
 @pytest.mark.django_db
@@ -236,12 +244,12 @@ def test_ops_case_detail_add_note_post_refreshes_timeline(client) -> None:
     assert response.status_code == 200
     assert CaseNote.objects.filter(return_case=return_case).count() == 1
     assert CaseEvent.objects.filter(return_case=return_case, event_type="note_added").count() == 1
-    assert "Internal note added." in payload["action_panel_html"]
+    assert "Internal note added." in payload["notes_panel_html"]
     assert "note_added" in payload["timeline_html"].lower()
     assert "replacement stock is available" in payload["timeline_html"].lower()
     assert (
         "Merchant called back and confirmed replacement stock is available."
-        in payload["action_panel_html"]
+        in payload["notes_panel_html"]
     )
 
 
@@ -302,7 +310,7 @@ def test_ops_case_detail_request_info_invalid_submission_returns_local_form_erro
 
 @pytest.mark.django_db
 def test_ops_case_detail_add_note_invalid_submission_returns_local_form_errors(client) -> None:
-    """Invalid note submissions should stay inside the action panel."""
+    """Invalid note submissions should stay inside the notes panel."""
 
     ops_user = UserFactory(email="ops-note-invalid@example.com")
     add_group(ops_user, "Ops")
@@ -321,12 +329,12 @@ def test_ops_case_detail_add_note_invalid_submission_returns_local_form_errors(c
     payload = response.json()
 
     assert response.status_code == 400
-    assert "problem with this note" in payload["action_panel_html"].lower()
+    assert "problem with this note" in payload["notes_panel_html"].lower()
 
 
 @pytest.mark.django_db
 def test_ops_case_detail_invalid_action_returns_local_error(client) -> None:
-    """Unknown ops actions should return a local action-panel error."""
+    """Unknown ops actions should return a local notes-panel error."""
 
     ops_user = UserFactory(email="ops-action-invalid@example.com")
     add_group(ops_user, "Ops")
@@ -342,7 +350,7 @@ def test_ops_case_detail_invalid_action_returns_local_error(client) -> None:
     payload = response.json()
 
     assert response.status_code == 400
-    assert "Choose a valid ops action." in payload["action_panel_html"]
+    assert "Choose a valid ops action." in payload["notes_panel_html"]
 
 
 @pytest.mark.django_db

--- a/tests/test_ops_case_detail.py
+++ b/tests/test_ops_case_detail.py
@@ -57,6 +57,20 @@ def test_ops_case_detail_renders_documents_timeline_and_risk(client) -> None:
     assert "Request information" in content
     assert "Save internal note" in content
     assert "Internal notes" in content
+    assert 'id="case-status-panel"' in content
+    assert 'data-loading-label="Updating workflow state"' in content
+    assert 'id="case-notes-panel"' in content
+    assert 'data-loading-label="Updating internal notes"' in content
+    assert 'id="case-document-table"' in content
+    assert 'data-loading-label="Updating case documents"' in content
+    assert 'id="case-timeline"' in content
+    assert 'data-loading-label="Updating audit timeline"' in content
+    assert 'id="case-risk-panel"' in content
+    assert 'data-loading-label="Updating risk summary"' in content
+    assert 'id="case-action-panel"' in content
+    assert 'data-loading-label="Updating case actions"' in content
+    assert 'id="case-upload-panel"' in content
+    assert 'data-loading-label="Updating upload panel"' in content
     assert (
         content.index("Workflow state")
         < content.index("Internal notes")


### PR DESCRIPTION
**Summary**
Add an ops-specific presentation pass across the queue and case detail surfaces, with clearer section hierarchy, richer panel layouts, and explicit loading feedback for inline fragment updates.

**Changes**
- introduced a dedicated quick-navigation/action strip on the ops case detail page
- moved internal notes into the main reading flow between workflow state and documents
- refreshed the queue shell and case detail copy to better reflect the ops workspace language
- redesigned the documents panel into card-style file entries with direct open actions
- redesigned the audit timeline into card-style event entries with actor and timestamp context
- added semantic fragment wrapper IDs and loading metadata for case detail sections
- added visible loading states with `aria-busy`, live status text, and dimmed panel content during inline refreshes
- updated the ops detail fragment update flow so notes refresh independently from the action panel
- updated runbook coverage and test assertions to match the new layout, copy, anchors, and note placement

**Why**
The ops pages had the right underlying workflows but still felt structurally flat and inconsistent in presentation. This change gives the queue and case-detail screens a clearer ops-specific hierarchy, makes the primary review path easier to follow, improves direct access to key sections, and provides visible feedback while inline actions are processing.

**Validation**
- `docker compose exec -T web pytest -q tests/test_ops_case_detail.py`
- `docker compose exec -T web python -m ruff check tests/test_ops_case_detail.py console/views.py`
- Sprint 5 Day 4 runbook updated and executed successfully during verification
- manual browser verification completed for case-detail layout and narrow-width behavior
- follow-up queue shell test assertions updated to match the new ops copy

**Result**
The ops UI now reads more deliberately as an operational workspace: queue language is tighter, case detail has a clearer reading order, notes are easier to review in context, documents and timeline are more scannable, and inline updates expose explicit loading states instead of silent panel swaps.

**Notes**
No separate `ops.css` layer was introduced. The presentation changes stay within the project’s shared `rh-*` design system, with minimal shared CSS added only for fragment loading states.