### PR TITLE
Chore/update docs sprint 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,40 @@
-# ReturnHub: Online Retailer Returns Escalation Platform
+# ReturnHub
 
-![CI Pipeline](https://img.shields.io/badge/CI-GitHub_Actions-blue)
-![Tests](https://img.shields.io/badge/tests-pytest-green)
-![Coverage](https://img.shields.io/badge/coverage-gated-brightgreen)
-![Code Style](https://img.shields.io/badge/code_style-black-black)
-![Lint](https://img.shields.io/badge/lint-ruff-2ea44f)
-![Python](https://img.shields.io/badge/python-3.12-blue)
-![Django](https://img.shields.io/badge/django-5.x-0c4b33)
-![Docker](https://img.shields.io/badge/docker-compose-2496ed)
-![License](https://img.shields.io/badge/license-MIT-lightgrey)
+ReturnHub is a Django 5 application for managing online-retail return cases across customer, merchant, ops, and admin roles. The project combines server-rendered workflow surfaces with DRF APIs, a service-layer workflow core, persisted audit events, and artifact-backed escalation-risk scoring.
 
-ReturnHub is a Django application for online retailer returns and customer support. It is designed as an API-first workflow product with server-rendered UI surfaces for ops teams, customers, merchants, and administrators. The system centralises return cases, evidence, notes, audit events, analytics, and persisted escalation-risk scoring behind shared domain and service-layer contracts.
-
-## Current status
+## Current state
 
 The repository currently includes:
 
-- Docker-based local development workflow
-- PostgreSQL-backed Django app
-- split development and test settings
-- core accounts and returns domain models
-- deterministic demo seed data
-- public landing page and role entry routes
-- authenticated console dashboards for admin, ops, customer, and merchant roles
-- project-aligned case detail workspace with documents, timeline, risk summary, and inline uploads
-- returns workflow API endpoints for create, detail, status, notes, and risk
-- document upload/list APIs and audit-export support
-- returns analytics API endpoint
-- ML registry, feature contract, seeded baseline training, artifact-backed scoring, and persisted `RiskScore` output
-- branded 403, 404, and 500 pages
-- CI workflow for lint, format, tests, and coverage
+- Django 5.1 + Django REST Framework on Python 3.12
+- PostgreSQL-backed local development through Docker Compose
+- seeded demo users, groups, profiles, and 32 stable return cases
+- public landing and role-entry pages
+- authenticated console dashboards for admin, ops, customer, and merchant users
+- a standalone ops queue at `/ops/` with filtering, ordering, summary cards, and shared pagination
+- an ops case-detail workspace at `/ops/{case_id}/` with inline status changes, follow-up requests, internal notes, timeline, risk panel, and evidence list
+- a shared case detail route at `/cases/{case_id}/` with role-aware document visibility and inline uploads
+- returns APIs for case creation, detail, status updates, notes, queue, documents, risk, and audit export
+- bounded analytics at `/api/analytics/returns/`
+- ML training, retraining, dataset generation, committed registry metadata, and persisted `RiskScore` records
+- pytest coverage across the workflow, UI, ML, API, and operations layers
 
-## Product stance
+## Architecture
 
-ReturnHub is API-first for core workflow, with Django Templates, Bootstrap 5.3, and small progressive JavaScript used for product surfaces built on the same domain model and service boundaries.
+ReturnHub is organized around a shared domain model and service layer:
 
-The UI is not treated as decoration. Public and authenticated surfaces exist to make workflow state, role boundaries, and operational context visible in the same product shell while the API and service layer remain the canonical source of behavior.
+- `accounts/` defines customer and merchant profiles
+- `returns/` owns return cases, documents, notes, audit events, risk persistence, workflow services, and ops APIs
+- `api/` exposes compatibility views and serializers for the live returns/document APIs
+- `analytics/` exposes bounded return metrics for ops and admins
+- `console/` serves authenticated dashboard and ops workflow pages
+- `ui/` serves public pages, the shared case workspace, and branded error pages
+- `ml/` owns feature extraction, scoring, model registry access, training flows, and reason-code generation
+- `common/` provides shared pagination, context processors, and demo-data seeding
 
-## Tech stack
+## Core domain
 
-- Python 3.12
-- Django 5.x
-- Django REST Framework
-- PostgreSQL
-- Docker Compose
-- pytest and pytest-django
-- factory_boy
-- Ruff
-- Black
-- Bootstrap 5.3
-- CSS design tokens
-
-## Feature summary
-
-### Reproducible environment
-
-The application runs locally with Docker Compose and PostgreSQL. Split settings keep development and test concerns separate while keeping both environments aligned to PostgreSQL.
-
-### Core domain models
-
-The returns domain currently includes:
+Main models:
 
 - `CustomerProfile`
 - `MerchantProfile`
@@ -69,24 +44,28 @@ The returns domain currently includes:
 - `CaseEvent`
 - `RiskScore`
 
-These models establish ownership boundaries, append-only audit structure, and persisted risk output for the implemented workflow.
+`ReturnCase` supports these statuses:
 
-### Deterministic demo data
+- `submitted`
+- `in_review`
+- `waiting_customer`
+- `waiting_merchant`
+- `approved`
+- `rejected`
 
-A management command seeds stable demo users, groups, and return cases. The seed path is idempotent, so repeated runs do not inflate counts or create data drift. This makes API walkthroughs, UI checks, pagination verification, and permission tests reliable.
+`ReturnCase` supports these priorities:
 
-Demo users created by the seed command:
+- `low`
+- `medium`
+- `high`
+- `urgent`
 
-- `admin`
-- `ops`
-- `customer`
-- `merchant`
+`EvidenceDocument` supports these kinds:
 
-Password for all local demo users:
+- `evidence`
+- `response`
 
-- `password123`
-
-### Public and authenticated UI surfaces
+## Implemented surfaces
 
 Public routes:
 
@@ -103,102 +82,74 @@ Authenticated console routes:
 - `/console/customer/`
 - `/console/merchant/`
 
-Case workspace route:
+Workflow routes:
 
-- `/cases/{id}/`
+- `/ops/`
+- `/ops/{case_id}/`
+- `/cases/{case_id}/`
+- `/cases/{case_id}/documents/upload/`
 
-The landing page is branded and responsive, with clear role entry points and a shared app shell. The authenticated console routes render role-aware dashboard shells inside the same visual system, and the case workspace provides document review, timeline history, risk context, and inline uploads.
+## API surface
 
-### Returns API and risk output
-
-The returns workflow API currently includes:
+Live application routes exposed by `config/urls.py`:
 
 - `POST /api/returns/`
-- `GET /api/returns/{id}/`
-- `PATCH /api/returns/{id}/status/`
-- `POST /api/returns/{id}/notes/`
-- `GET /api/returns/{id}/documents/`
-- `POST /api/returns/{id}/documents/`
-- `GET /api/returns/{id}/risk/`
-- `GET /api/returns/{id}/audit-export/`
+- `GET /api/returns/{case_id}/`
+- `PATCH /api/returns/{case_id}/status/`
+- `POST /api/returns/{case_id}/notes/`
+- `GET /api/returns/queue/`
+- `GET /api/returns/{case_id}/documents/`
+- `POST /api/returns/{case_id}/documents/`
+- `GET /api/returns/{case_id}/risk/`
+- `GET /api/returns/{case_id}/audit-export/`
+- `GET /api/analytics/returns/?from=YYYY-MM-DD&to=YYYY-MM-DD`
 
-Risk output is persisted to `RiskScore` records and exposed only to ops and admin users. Customer-facing case detail keeps `risk` hidden as `null`.
+Behavioral rules currently enforced in code:
 
-### Analytics and ML scaffolding
+- customers and admins can create return cases
+- ops and admins can update status, set priority, and add internal notes
+- customers only see their own cases
+- merchants only see cases tied to their merchant profile
+- ops and admins can see all cases
+- risk payloads are visible only to ops and admins
+- customers can upload only `evidence` to their own cases
+- merchants can upload only `response` to their own cases
+- ops and admins can upload either document kind
+- document uploads emit audit events and trigger a best-effort rescore
 
-The project also includes:
+## Ops queue contract
 
-- `GET /api/analytics/returns/` for bounded returns analytics
-- a committed ML registry at `ml/registry/model_registry.json`
-- seeded baseline model training, retraining, and dataset export commands
-- artifact-backed scoring with deterministic fallback and structured reason-code generation
-- persisted `risk_scored` audit events linked to return cases
+The server-rendered ops queue and the DRF queue endpoint share the same service-layer contract:
 
-### Shared pagination contract
+- filters: `status`, `priority`, `risk_label`, `search`, `page`
+- risk labels: `low`, `medium`, `high`
+- page size: `15`
+- invalid or missing page values normalize to page `1`
+- ordering:
+  1. SLA-breached active cases first
+  2. higher priority first
+  3. earlier `sla_due_at`
+  4. earlier `created_at`
+  5. `id` as final tiebreaker
 
-ReturnHub adopts one pagination contract early so list pages do not drift. The shared utility and partial implement:
+## ML and analytics
 
-- `page` query parameter
-- fixed page size of `15`
-- missing page resolves to page 1
-- invalid page resolves to page 1
-- `page <= 0` resolves to page 1
-- out-of-range page resolves to the last page
-- filter-preserving page links
-- count line format `Showing {start}-{end} of {total}`
+The project includes:
 
-## Repository structure
+- a committed feature contract at `ml/contracts/return_case_features.json`
+- artifact-backed scoring with fallback placeholder scoring
+- reason-code generation for persisted risk records
+- a committed model registry at `ml/registry/model_registry.json`
+- training, retraining, and dataset-generation management commands
 
-```text
-.
-├── accounts/
-├── api/
-├── analytics/
-│   ├── api/
-│   └── services/
-├── common/
-│   ├── management/
-│   └── templatetags/
-├── config/
-│   └── settings/
-├── console/
-├── docs/
-│   ├── api/
-│   ├── ml/
-│   └── ui/
-├── ml/
-│   ├── contracts/
-│   ├── datasets/
-│   ├── management/
-│   └── registry/
-├── requirements/
-├── returns/
-│   ├── api/
-│   ├── migrations/
-│   └── services/
-├── static/
-│   ├── css/
-│   └── images/
-├── templates/
-│   ├── console/
-│   ├── errors/
-│   ├── partials/
-│   └── public/
-├── tests/
-├── ui/
-├── .github/
-│   └── workflows/
-├── docker-compose.yml
-├── Dockerfile
-├── manage.py
-├── pyproject.toml
-├── README.md
-└── RUNBOOK.md
-```
+Current committed active model:
 
-## Quick start
+- version: `retrain_baseline-logreg-v1-seed-7-rows-500`
+- model type: `logistic_regression`
+- contract version: `return-risk-sprint2-v1`
+- reason code schema: `return-risk-reasons-sprint3-v1`
 
-Clone the repository, create the environment file, start Docker services, run migrations, and seed demo data.
+## Local setup
 
 ```bash
 cp .env.example .env
@@ -207,235 +158,73 @@ docker compose exec -T web python manage.py migrate --noinput
 docker compose exec -T web python manage.py seed_demo_data
 ```
 
-Open the app at:
+Application URL:
 
 ```text
 http://127.0.0.1:8000/
 ```
 
-Useful local surfaces:
+Demo users created by `seed_demo_data`:
 
-- landing page: `/`
-- public role entry pages: `/login/admin/`, `/login/ops/`, `/login/customer/`, `/login/merchant/`
-- authenticated console pages: `/console/admin/`, `/console/ops/`, `/console/customer/`, `/console/merchant/`
-- case detail workspace: `/cases/{id}/`
+- `admin`
+- `ops`
+- `customer`
+- `merchant`
 
-## Local development commands
+Shared local password:
 
-Run the test suite:
+- `password123`
 
-```bash
-docker compose exec -T web pytest -q
-```
-
-Run lint checks:
+## Useful commands
 
 ```bash
-docker compose exec -T web python -m ruff check .
+make bootstrap
+make up
+make migrate
+make test
+make test-cov
+make lint
+make format-check
+make check
+docker compose exec -T web python manage.py generate_training_dataset --seed 7 --rows 300
+docker compose exec -T web python manage.py train_escalation_model --seed 7 --size 500
+docker compose exec -T web python manage.py retrain_baseline_model --seed 7 --rows 500
 ```
 
-Run formatting check:
-
-```bash
-docker compose exec -T web python -m black . --check
-```
-
-Create migrations after model changes:
-
-```bash
-docker compose exec -T web python manage.py makemigrations
-```
-
-Apply migrations:
-
-```bash
-docker compose exec -T web python manage.py migrate --noinput
-```
-
-Re-seed deterministic demo data:
-
-```bash
-docker compose exec -T web python manage.py seed_demo_data
-```
-
-Train and register the baseline escalation model:
-
-```bash
-docker compose exec -T web python manage.py train_escalation_model
-```
-
-Retrain the baseline model with the evidence-aware dataset path:
-
-```bash
-docker compose exec -T web python manage.py retrain_baseline_model
-```
-
-Generate the evidence-aware training dataset CSV:
-
-```bash
-docker compose exec -T web python manage.py generate_training_dataset
-```
-
-Run tests with coverage:
-
-```bash
-docker compose exec -T web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80
-```
-
-## Local verification checklist
-
-After setup, confirm the following:
-
-- the landing page loads at `/`
-- all four public surface entry pages load successfully
-- authenticated console pages render for seeded users
-- a case detail workspace renders at `/cases/{id}/`
-- linked actors can upload a document and see local panel feedback with the document table refreshed in place
-- the seed command completes successfully
-- `ReturnCase.objects.count()` returns `32`
-- the returns API create and detail paths work
-- the risk endpoint returns `200` for ops and `403` for customers and merchants
-- pytest passes
-- Ruff passes
-- Black check passes
-- custom 404 handling uses branded product templates
-
-## Example expected outputs
-
-Seed command:
+## Repository map
 
 ```text
-Seed complete. Stable return case count: 32
+.
+├── accounts/
+├── analytics/
+├── api/
+├── common/
+├── config/
+├── console/
+├── docs/
+│   ├── api/
+│   ├── ml/
+│   └── ui/
+├── ml/
+├── returns/
+├── static/
+├── templates/
+├── tests/
+├── ui/
+├── Dockerfile
+├── Makefile
+├── README.md
+└── RUNBOOK.md
 ```
 
-On long-lived local databases that already contain extra runbook-generated cases, the seed command remains idempotent for its fixture rows but the printed total count may be higher than `32`. Use `docker compose down -v` before reseeding if you need the clean baseline count.
+## Documentation map
 
-Pytest summary:
-
-```text
-<all tests pass>
-```
-
-Shell check for case count:
-
-```text
-32
-```
-
-Pagination count line example with seeded data:
-
-```text
-Showing 31-32 of 32
-```
-
-## Frontend artefacts
-
-The repository includes reusable frontend building blocks such as:
-
-- `docs/ui/product-ui-brief.md`
-- `docs/ui/design-system.md`
-- `templates/base.html`
-- `templates/public/landing.html`
-- `templates/public/surface_entry.html`
-- `templates/console/admin_dashboard.html`
-- `templates/console/ops_dashboard.html`
-- `templates/console/customer_dashboard.html`
-- `templates/console/merchant_dashboard.html`
-- `templates/cases/detail.html`
-- `templates/partials/_app_nav.html`
-- `templates/partials/_console_hero_shell.html`
-- `templates/partials/_console_recent_case_cards.html`
-- `templates/partials/_console_recent_cases_section.html`
-- `templates/partials/_console_visual_timeline.html`
-- `templates/partials/_document_table.html`
-- `templates/partials/_flash_messages.html`
-- `templates/partials/_empty_state.html`
-- `templates/partials/_form_errors.html`
-- `templates/partials/_risk_summary.html`
-- `templates/partials/_status_badge.html`
-- `templates/partials/_timeline.html`
-- `templates/partials/_upload_panel.html`
-- `templates/partials/_pagination.html`
-- `templates/errors/403.html`
-- `templates/errors/404.html`
-- `templates/errors/500.html`
-- `static/css/tokens.css`
-- `static/css/app.css`
-
-## Quality bar
-
-This project is being built with a production-minded quality bar:
-
-- docstrings on public modules, classes, and functions
-- shared contracts for behaviour that spans multiple surfaces
-- database-backed integration tests for persistence-critical workflows
-- deterministic demo data and predictable walkthroughs
-- CI gates for lint, format, tests, and coverage
-- accessible, responsive server-rendered UI foundations
-
-## CI
-
-GitHub Actions runs the following checks:
-
-- migrations
-- Ruff
-- Black check
-- pytest with coverage
-- coverage threshold gate
-
-## Troubleshooting
-
-### Docker container does not start
-
-Check container status:
-
-```bash
-docker compose ps
-```
-
-Inspect logs:
-
-```bash
-docker compose logs web
-docker compose logs db
-```
-
-### PostgreSQL connection issue
-
-Confirm `.env` exists and that these values are set correctly:
-
-- `POSTGRES_DB`
-- `POSTGRES_USER`
-- `POSTGRES_PASSWORD`
-- `POSTGRES_HOST`
-- `POSTGRES_PORT`
-
-### Tests fail because of stale local state
-
-Reset containers and volumes, then rebuild:
-
-```bash
-docker compose down -v
-docker compose up --build -d
-docker compose exec -T web python manage.py migrate --noinput
-docker compose exec -T web python manage.py seed_demo_data
-```
-
-### `APIClient` requests fail in `manage.py shell`
-
-When using `rest_framework.test.APIClient` in `manage.py shell`, pass `HTTP_HOST="localhost"` so the request uses an allowed host instead of the default `testserver`.
-
-## Documentation
-
-- `README.md` gives the project overview and setup path.
-- `RUNBOOK.md` provides the current clone-to-verified workflow.
-- `docs/api/returns-workflow.md` documents the returns workflow API.
-- `docs/ml/baseline-escalation-risk.md` documents the seeded baseline training flow.
-- `docs/ml/model-registry.md` documents the ML registry contract.
-- `docs/ui/evidence-states.md` documents case-detail evidence UI states.
-- `docs/ui/product-ui-brief.md` defines the frontend purpose and layout direction.
-- `docs/ui/design-system.md` defines the visual system foundation.
-
-## License
-
-MIT License.
+- `README.md`: project overview and current-state summary
+- `RUNBOOK.md`: bootstrap and manual verification flow
+- `docs/api/returns-workflow.md`: returns API behavior and permissions
+- `docs/api/ops-queue-contract.md`: shared queue filter, ordering, and pagination contract
+- `docs/ml/baseline-escalation-risk.md`: training, inference, and artifact flow
+- `docs/ml/model-registry.md`: registry structure and active-model metadata
+- `docs/ui/product-ui-brief.md`: product-surface intent and route map
+- `docs/ui/design-system.md`: tokens, layout patterns, and component rules
+- `docs/ui/evidence-states.md`: case detail and document-upload state handling

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # ReturnHub Runbook
 
-This runbook takes the project from clean clone to a verified local environment and checks the routes, workflows, APIs, and ML artifacts that currently exist in the repository.
+This runbook takes the project from clean clone to a verified local environment and checks the routes, workflows, APIs, ML artifacts, and proof commands that currently match the repository.
 
 ## Scope
 
@@ -12,8 +12,9 @@ This runbook verifies:
 - ops queue and ops case-detail workflows
 - shared case-detail document upload flow
 - returns, documents, queue, risk, audit-export, and analytics APIs
-- ML dataset/training commands and committed registry state
+- ML dataset and training commands
 - formatting, lint, tests, and coverage gate commands
+- console-only proof commands suitable for article evidence
 
 ## Prerequisites
 
@@ -135,7 +136,7 @@ Expected behavior:
 
 ## Authenticated route verification
 
-Log in through the Django admin or shell-created sessions, then open:
+Log in with a seeded user, then open:
 
 - `http://127.0.0.1:8000/console/admin/`
 - `http://127.0.0.1:8000/console/ops/`
@@ -163,6 +164,7 @@ Verify:
 - queue filters accept `status`, `priority`, `risk_label`, `search`, and `page`
 - pagination uses a page size of `15`
 - invalid pages normalize to page `1`
+- out-of-range pages resolve to the last page
 - summary counts update with filtered results
 
 Check the API equivalent while authenticated as ops or admin:
@@ -188,25 +190,44 @@ http://127.0.0.1:8000/ops/<case_id>/
 Verify the page renders:
 
 - case header
-- status panel
-- risk panel
+- quick navigation
+- workflow state panel
 - notes panel
+- documents panel
 - timeline
+- risk panel
 - action panel
-- evidence list
-
-From the action panel:
-
-- update status to an allowed next state
-- request information from customer or merchant
-- add an internal note
+- upload panel
 
 Expected behavior:
 
-- invalid transitions are rejected
-- successful actions refresh the case view
-- status changes emit `status_updated`
-- notes emit `note_added`
+- the route is `ops:case-detail`
+- the page renders current workflow state and ownership context
+- the page includes documents, notes, timeline, and risk sections
+- sparse cases show stable empty states such as `No documents yet`, `No notes yet`, `No timeline events yet`, and `No score yet`
+
+## Ops actions verification
+
+The ops case-detail page handles inline actions through the same `ops:case-detail` route. It does not use separate `/workflow/`, `/request-info/`, or `/notes/` endpoints.
+
+Supported actions posted to `/ops/<case_id>/`:
+
+- `ops_action=case-update`
+- `ops_action=request-info`
+- `ops_action=add-note`
+
+Expected behavior:
+
+- valid status updates return `200`
+- request-for-information moves the case into `waiting_customer` or `waiting_merchant`
+- note creation returns `200`
+- invalid submissions return `400` with local panel errors
+- unauthorized customer submissions return `403`
+
+Expected event types:
+
+- status changes and request-for-information actions emit `status_updated`
+- note creation emits `note_added`
 
 ## Shared case-detail and upload verification
 
@@ -433,3 +454,46 @@ Equivalent Make targets:
 - `make format`
 - `make format-check`
 - `make check`
+
+## Proof Commands
+
+These commands are designed for article evidence. They suppress noisy expected error traces by:
+
+- using `Client(HTTP_HOST='localhost', raise_request_exception=False)`
+- disabling the `django.request` logger inside the shell command
+
+### Queue verification proof
+
+```bash
+docker compose exec web python manage.py shell -c "import logging; from django.test import Client; from django.urls import resolve; from django.contrib.auth import get_user_model; from returns.services.queue import build_queue_queryset, parse_queue_filters; from common.pagination import paginate_queryset; logging.getLogger('django.request').disabled = True; User = get_user_model(); client = Client(HTTP_HOST='localhost', raise_request_exception=False); user = User.objects.filter(groups__name__iexact='Ops').first() or User.objects.filter(is_superuser=True).first(); client.force_login(user); queryset = build_queue_queryset(parse_queue_filters({})); invalid_page = paginate_queryset(queryset, 'abc').page_obj; zero_page = paginate_queryset(queryset, '0').page_obj; last_page = paginate_queryset(queryset, '999').page_obj; full = client.get('/ops/'); htmx = client.get('/ops/', HTTP_HX_REQUEST='true'); empty = client.get('/ops/?status=closed&priority=high&search=unlikely_runbook_value'); full_content = full.content.decode(); htmx_content = htmx.content.decode(); empty_content = empty.content.decode(); print('OPS_QUEUE_URL=/ops/'); print('OPS_QUEUE_VIEW=ops:queue'); print(f'OPS_QUEUE_ROUTE_CHECK={resolve(\"/ops/\").view_name == \"ops:queue\"}'); print(f'OPS_QUEUE_PAGE_RENDER_CHECK={full.status_code == 200 and \"Returns queue\" in full_content}'); print(f'OPS_QUEUE_PAGINATION_CHECK={invalid_page.number == 1 and zero_page.number == 1 and last_page.number == last_page.paginator.num_pages}'); print(f'OPS_QUEUE_HTMX_PARTIAL_CHECK={htmx.status_code == 200 and \"Return cases\" in htmx_content and \"Showing\" in htmx_content}'); print(f'OPS_QUEUE_EMPTY_STATE_CHECK={\"No cases match these filters\" in empty_content}')"
+```
+
+### Case detail verification proof
+
+```bash
+docker compose exec web python manage.py shell -c "import logging; from django.test import Client; from django.urls import reverse, resolve; from django.contrib.auth import get_user_model; from returns.models import ReturnCase; logging.getLogger('django.request').disabled = True; User = get_user_model(); client = Client(HTTP_HOST='localhost', raise_request_exception=False); user = User.objects.filter(groups__name__iexact='Ops').first() or User.objects.filter(is_superuser=True).first(); case = ReturnCase.objects.order_by('id').first(); sparse_case = ReturnCase.objects.filter(documents__isnull=True, risk_score__isnull=True, notes__isnull=True, events__isnull=True).distinct().first() or case; client.force_login(user); response = client.get(reverse('ops:case-detail', args=[case.pk])); sparse_response = client.get(reverse('ops:case-detail', args=[sparse_case.pk])); content = response.content.decode(); sparse_content = sparse_response.content.decode(); print(f'CASE_ID={case.pk}'); print(f'CASE_REFERENCE={case.order_reference}'); print(f'OPS_CASE_DETAIL_URL={reverse(\"ops:case-detail\", args=[case.pk])}'); print('OPS_CASE_DETAIL_VIEW=ops:case-detail'); print(f'OPS_CASE_DETAIL_ROUTE_CHECK={resolve(reverse(\"ops:case-detail\", args=[case.pk])).view_name == \"ops:case-detail\"}'); print(f'OPS_CASE_DETAIL_PAGE_RENDER_CHECK={response.status_code == 200}'); print(f'OPS_CASE_DETAIL_WORKFLOW_STATE_CHECK={\"Workflow state\" in content}'); print(f'OPS_CASE_DETAIL_DOCUMENTS_SECTION_CHECK={(\"Documents\" in content) or (\"Evidence\" in content)}'); print(f'OPS_CASE_DETAIL_TIMELINE_SECTION_CHECK={\"Audit timeline\" in content}'); print(f'OPS_CASE_DETAIL_RISK_PANEL_CHECK={\"Escalation risk\" in content}'); print(f'OPS_CASE_DETAIL_EMPTY_DOCUMENTS_CHECK={\"No documents yet\" in sparse_content}'); print(f'OPS_CASE_DETAIL_EMPTY_RISK_CHECK={\"No score yet\" in sparse_content}')"
+```
+
+### Workflow action proof
+
+```bash
+docker compose exec web python manage.py shell -c "import logging; from django.test import Client; from django.contrib.auth import get_user_model; from returns.models import ReturnCase, CaseEvent, CaseNote; logging.getLogger('django.request').disabled = True; User = get_user_model(); client = Client(HTTP_HOST='localhost', raise_request_exception=False); ops_user = User.objects.filter(groups__name__iexact='Ops').first() or User.objects.filter(is_superuser=True).first(); customer_user = User.objects.filter(groups__name__iexact='Customer').first(); update_case = ReturnCase.objects.filter(status='submitted').order_by('id').first() or ReturnCase.objects.order_by('id').first(); request_case = ReturnCase.objects.filter(status='submitted').exclude(pk=update_case.pk).order_by('id').first() or update_case; note_case = ReturnCase.objects.exclude(pk__in=[update_case.pk, request_case.pk]).order_by('id').first() or update_case; invalid_case = ReturnCase.objects.filter(status='approved').order_by('id').first() or update_case; client.force_login(ops_user); workflow_response = client.post(f'/ops/{update_case.pk}/', {'ops_action': 'case-update', 'status': 'in_review', 'priority': 'high'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); update_case.refresh_from_db(); workflow_event = CaseEvent.objects.filter(return_case=update_case, event_type='status_updated', payload__new_status='in_review').exists(); request_response = client.post(f'/ops/{request_case.pk}/', {'ops_action': 'request-info', 'recipient': 'customer', 'message': 'Please upload a clearer image of the damaged item.'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); request_case.refresh_from_db(); request_event = CaseEvent.objects.filter(return_case=request_case, event_type='status_updated', payload__note__icontains='Requested additional information from customer').exists(); note_body = 'Customer appears responsive. Await merchant packaging confirmation.'; note_response = client.post(f'/ops/{note_case.pk}/', {'ops_action': 'add-note', 'body': note_body}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); note_event = CaseEvent.objects.filter(return_case=note_case, event_type='note_added').exists(); note_saved = CaseNote.objects.filter(return_case=note_case, body=note_body).exists(); invalid_response = client.post(f'/ops/{invalid_case.pk}/', {'ops_action': 'case-update', 'status': '', 'priority': ''}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); invalid_html = invalid_response.json().get('action_panel_html', ''); client.force_login(customer_user); wrong_role_response = client.post(f'/ops/{note_case.pk}/', {'ops_action': 'add-note', 'body': 'Unauthorised note attempt'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); print(f'OPS_WORKFLOW_UPDATE_CHECK={workflow_response.status_code == 200 and update_case.status == \"in_review\" and update_case.priority == \"high\" and workflow_event}'); print(f'OPS_REQUEST_INFO_CHECK={request_response.status_code == 200 and request_case.status == \"waiting_customer\" and request_event}'); print(f'OPS_ADD_NOTE_CHECK={note_response.status_code == 200 and note_saved and note_event}'); print(f'OPS_INVALID_WORKFLOW_CHECK={invalid_response.status_code == 400}'); print(f'OPS_INVALID_WORKFLOW_ERROR_CHECK={\"This field is required.\" in invalid_html}'); print(f'OPS_ACTION_WRONG_ROLE_CHECK={wrong_role_response.status_code == 403}')"
+```
+
+### Layout verification proof
+
+```bash
+docker compose exec web python manage.py shell -c "import logging; from django.test import Client; from django.contrib.auth import get_user_model; from returns.models import ReturnCase, CaseNote; logging.getLogger('django.request').disabled = True; User = get_user_model(); client = Client(HTTP_HOST='localhost', raise_request_exception=False); user = User.objects.filter(groups__name__iexact='Ops').first() or User.objects.filter(is_superuser=True).first(); nav_case = ReturnCase.objects.order_by('id').first(); sparse_case = ReturnCase.objects.exclude(pk=nav_case.pk).order_by('id').first() or nav_case; CaseNote.objects.filter(return_case=nav_case).delete(); CaseNote.objects.filter(return_case=sparse_case).delete(); CaseNote.objects.create(return_case=nav_case, author=user, body='Older note for ordering check'); CaseNote.objects.create(return_case=nav_case, author=user, body='Newer note for ordering check'); client.force_login(user); response = client.get(f'/ops/{nav_case.pk}/'); sparse_response = client.get(f'/ops/{sparse_case.pk}/'); content = response.content.decode(); sparse_content = sparse_response.content.decode(); print(f'OPS_CASE_DETAIL_QUICK_NAVIGATION_CHECK={\"Quick navigation\" in content}'); print(f'OPS_ACTION_BAR_WORKFLOW_LINK_CHECK={\"#case-status-panel\" in content}'); print(f'OPS_ACTION_BAR_NOTES_LINK_CHECK={\"#case-notes-panel\" in content}'); print(f'OPS_ACTION_BAR_DOCUMENTS_LINK_CHECK={\"#case-document-table\" in content}'); print(f'OPS_ACTION_BAR_TIMELINE_LINK_CHECK={\"#case-timeline\" in content}'); print(f'OPS_CASE_DETAIL_NOTES_PLACEMENT_CHECK={content.index(\"Workflow state\") < content.index(\"Internal notes\") < content.index(\"Documents\")}'); print(f'OPS_NOTES_ORDERING_RENDER_CHECK={content.index(\"Newer note for ordering check\") < content.index(\"Older note for ordering check\")}'); print(f'OPS_EMPTY_NOTES_CHECK={\"No notes yet\" in sparse_content}')"
+```
+
+### Day 5 ops surface proof
+
+```bash
+docker compose exec web python manage.py shell -c "import logging; from django.test import Client; from django.contrib.auth import get_user_model; from returns.models import ReturnCase; logging.getLogger('django.request').disabled = True; User = get_user_model(); client = Client(HTTP_HOST='localhost', raise_request_exception=False); user = User.objects.filter(groups__name__iexact='Ops').first() or User.objects.filter(is_superuser=True).first(); first_case = ReturnCase.objects.order_by('id').first(); sparse_case = ReturnCase.objects.filter(order_reference='RH-RUNBOOK-SPARSE').first() or first_case; client.force_login(user); queue = client.get('/ops/'); detail = client.get(f'/ops/{first_case.pk}/'); page_two = client.get('/ops/?page=2'); empty = client.get('/ops/?status=closed&priority=high&search=unlikely_runbook_value'); sparse = client.get(f'/ops/{sparse_case.pk}/'); queue_content = queue.content.decode(); detail_content = detail.content.decode(); empty_content = empty.content.decode(); sparse_content = sparse.content.decode(); print(f'OPS_QUEUE_SMOKE_RENDER_CHECK={queue.status_code == 200 and \"Returns queue\" in queue_content}'); print(f'OPS_DETAIL_SMOKE_RENDER_CHECK={detail.status_code == 200 and first_case.order_reference in detail_content}'); print(f'OPS_QUEUE_PAGE_TWO_CHECK={page_two.status_code == 200 and \"Showing 16-\" in page_two.content.decode()}'); print(f'OPS_QUEUE_EMPTY_STATE_CHECK={\"No cases match these filters\" in empty_content}'); print(f'OPS_DETAIL_EMPTY_DOCUMENTS_CHECK={\"No documents yet\" in sparse_content}'); print(f'OPS_DETAIL_EMPTY_TIMELINE_CHECK={\"No timeline events yet\" in sparse_content}'); print(f'OPS_DETAIL_LOADING_LAYER_CHECK={(\"data-loading-label\" in detail_content) and (\"rh-fragment-panel__status\" in detail_content)}'); print(f'OPS_DETAIL_FRAGMENT_IDS_CHECK={(\"case-status-panel\" in detail_content) and (\"case-notes-panel\" in detail_content)}')"
+```
+
+### Compact console proof
+
+```bash
+bash -lc "docker compose exec web pytest -q tests/test_ops_queue.py tests/test_ops_case_detail.py tests/test_ops_console.py tests/test_console_shell.py tests/test_case_detail_empty_states.py tests/test_ops_queue_api.py && docker compose exec web python -m ruff check . && docker compose exec web python -m black . --check && docker compose exec web python manage.py shell -c \"import logging; from django.test import Client; from django.urls import resolve, reverse; from django.contrib.auth import get_user_model; from returns.models import ReturnCase, CaseEvent, CaseNote; logging.getLogger('django.request').disabled = True; User = get_user_model(); client = Client(HTTP_HOST='localhost', raise_request_exception=False); ops_user = User.objects.filter(groups__name__iexact='Ops').first() or User.objects.filter(is_superuser=True).first(); customer_user = User.objects.filter(groups__name__iexact='Customer').first(); queue_case = ReturnCase.objects.filter(status='submitted').order_by('id').first() or ReturnCase.objects.order_by('id').first(); request_case = ReturnCase.objects.filter(status='submitted').exclude(pk=queue_case.pk).order_by('id').first() or queue_case; note_case = ReturnCase.objects.exclude(pk__in=[queue_case.pk, request_case.pk]).order_by('id').first() or queue_case; client.force_login(ops_user); queue = client.get('/ops/'); detail = client.get(f'/ops/{queue_case.pk}/'); page_two = client.get('/ops/?page=2'); empty = client.get('/ops/?status=closed&priority=high&search=unlikely_runbook_value'); workflow = client.post(f'/ops/{queue_case.pk}/', {'ops_action': 'case-update', 'status': 'in_review', 'priority': 'high'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); queue_case.refresh_from_db(); request_info = client.post(f'/ops/{request_case.pk}/', {'ops_action': 'request-info', 'recipient': 'customer', 'message': 'Please upload a clearer image of the damaged item.'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); note_body = 'Compact proof note'; add_note = client.post(f'/ops/{note_case.pk}/', {'ops_action': 'add-note', 'body': note_body}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); CaseNote.objects.filter(return_case=queue_case).delete(); CaseNote.objects.create(return_case=queue_case, author=ops_user, body='Older compact proof note'); CaseNote.objects.create(return_case=queue_case, author=ops_user, body='Newer compact proof note'); detail_after = client.get(f'/ops/{queue_case.pk}/'); sparse_case = ReturnCase.objects.filter(order_reference='RH-RUNBOOK-SPARSE').first() or queue_case; sparse = client.get(f'/ops/{sparse_case.pk}/'); client.force_login(customer_user); wrong_role = client.post(f'/ops/{note_case.pk}/', {'ops_action': 'add-note', 'body': 'Unauthorised note attempt'}, HTTP_X_REQUESTED_WITH='XMLHttpRequest'); detail_content = detail_after.content.decode(); sparse_content = sparse.content.decode(); empty_content = empty.content.decode(); print(f'OPS_QUEUE_ROUTE_CHECK={resolve(\\\"/ops/\\\").view_name == \\\"ops:queue\\\"}'); print(f'OPS_QUEUE_PAGE_RENDER_CHECK={queue.status_code == 200}'); print(f'OPS_CASE_DETAIL_ROUTE_CHECK={resolve(reverse(\\\"ops:case-detail\\\", args=[queue_case.pk])).view_name == \\\"ops:case-detail\\\"}'); print(f'OPS_CASE_DETAIL_PAGE_RENDER_CHECK={detail.status_code == 200}'); print(f'OPS_WORKFLOW_UPDATE_CHECK={workflow.status_code == 200 and queue_case.status == \\\"in_review\\\" and queue_case.priority == \\\"high\\\" and CaseEvent.objects.filter(return_case=queue_case, event_type=\\\"status_updated\\\", payload__new_status=\\\"in_review\\\").exists()}'); print(f'OPS_REQUEST_INFO_CHECK={request_info.status_code == 200 and CaseEvent.objects.filter(return_case=request_case, event_type=\\\"status_updated\\\", payload__note__icontains=\\\"Requested additional information from customer\\\").exists()}'); print(f'OPS_ADD_NOTE_CHECK={add_note.status_code == 200 and CaseNote.objects.filter(return_case=note_case, body=note_body).exists() and CaseEvent.objects.filter(return_case=note_case, event_type=\\\"note_added\\\").exists()}'); print(f'OPS_NOTES_ORDERING_RENDER_CHECK={detail_content.index(\\\"Newer compact proof note\\\") < detail_content.index(\\\"Older compact proof note\\\")}'); print(f'OPS_QUEUE_PAGE_TWO_CHECK={page_two.status_code == 200 and \\\"Showing 16-\\\" in page_two.content.decode()}'); print(f'OPS_QUEUE_EMPTY_STATE_CHECK={\\\"No cases match these filters\\\" in empty_content}'); print(f'OPS_DETAIL_EMPTY_DOCUMENTS_CHECK={\\\"No documents yet\\\" in sparse_content}'); print(f'OPS_DETAIL_EMPTY_TIMELINE_CHECK={\\\"No timeline events yet\\\" in sparse_content}'); print(f'OPS_ACTION_WRONG_ROLE_CHECK={wrong_role.status_code == 403}')\""
+```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,57 +1,34 @@
-# ReturnHub Project Runbook
+# ReturnHub Runbook
 
-This runbook takes the project from clean clone to a verified current-state local environment. It is written for deterministic setup and manual verification of the implemented product surfaces, API behavior, risk output access controls, and local quality gates.
+This runbook takes the project from clean clone to a verified local environment and checks the routes, workflows, APIs, and ML artifacts that currently exist in the repository.
 
 ## Scope
 
-This runbook verifies the following outcomes:
+This runbook verifies:
 
-- Docker and PostgreSQL local environment
-- Django app boot and migrations
-- deterministic demo seed data
-- public UI routes
-- authenticated console routes
-- case detail workspace rendering and inline document uploads
-- returns API create, detail, status, notes, and risk behavior
-- returns document and audit-export behavior
-- risk visibility controls for ops, admins, customers, and merchants
-- API and ML documentation alignment checks
-- lint, formatting, test, and coverage checks
+- Docker-based local setup with PostgreSQL
+- Django migrations and deterministic demo data
+- public and authenticated UI routes
+- ops queue and ops case-detail workflows
+- shared case-detail document upload flow
+- returns, documents, queue, risk, audit-export, and analytics APIs
+- ML dataset/training commands and committed registry state
+- formatting, lint, tests, and coverage gate commands
 
 ## Prerequisites
-
-Before starting, confirm that the local machine has:
 
 - Git
 - Docker
 - Docker Compose
-- a free local port for `8000`
-- a free local port for `5432`
+- free ports `8000` and `5432`
 
-## Repository bootstrap
+## Bootstrap
 
-Clone the repository.
+Clone the repository and move into it.
 
 ```bash
 git clone <your-repo-url> returnhub
-```
-
-Expected result:
-
-```text
-A local `returnhub/` directory is created.
-```
-
-Move into the project directory.
-
-```bash
 cd returnhub
-```
-
-Expected result:
-
-```text
-The shell is now at the repository root.
 ```
 
 Create the local environment file.
@@ -60,58 +37,25 @@ Create the local environment file.
 cp .env.example .env
 ```
 
-Expected result:
-
-```text
-A local `.env` file exists at the repository root.
-```
-
-## Start containers
-
-Build and start the application and database containers.
+Start the containers.
 
 ```bash
 docker compose up --build -d
-```
-
-Expected result:
-
-```text
-The `db` and `web` services start successfully in detached mode.
-```
-
-Check container status.
-
-```bash
 docker compose ps
 ```
 
 Expected result:
 
-```text
-The `db` service is healthy and the `web` service is running.
-```
+- `db` is healthy
+- `web` is running
 
-## Apply database migrations
-
-Run migrations.
+Apply migrations.
 
 ```bash
 docker compose exec -T web python manage.py migrate --noinput
 ```
 
-Expected result shape:
-
-```text
-Operations to perform:
-  Apply all migrations: ...
-Running migrations:
-  No migrations to apply.
-```
-
-## Seed deterministic demo data
-
-Run the seed command.
+Seed demo data.
 
 ```bash
 docker compose exec -T web python manage.py seed_demo_data
@@ -123,813 +67,369 @@ Expected result:
 Seed complete. Stable return case count: 32
 ```
 
-On a clean database the count is `32`. In long-lived local environments that already contain extra runbook-generated cases, the seed command remains idempotent for its fixture rows but the printed total count may be higher.
-
-Run the seed command a second time to confirm idempotency.
+Run it again to confirm idempotency.
 
 ```bash
 docker compose exec -T web python manage.py seed_demo_data
 ```
 
-Expected result:
+## Verify seeded roles and users
 
-```text
-Seed complete. Stable return case count: 32
-```
-
-## Verify demo users and seeded case count
-
-Check the total return case count.
-
-```bash
-docker compose exec -T web python manage.py shell -c "from returns.models import ReturnCase; print(ReturnCase.objects.count())"
-```
-
-Expected result:
-
-```text
-32
-```
-
-If previous runbooks created extra cases in the same local database, this count may be greater than `32`. Use the clean reset procedure when you need the exact baseline fixture count.
-
-Check that the expected role groups exist.
+Check groups.
 
 ```bash
 docker compose exec -T web python manage.py shell -c "from django.contrib.auth.models import Group; print(list(Group.objects.order_by('name').values_list('name', flat=True)))"
 ```
 
-Expected result:
+Expected:
 
 ```text
 ['Admin', 'Customer', 'Merchant', 'Ops']
 ```
 
-Check the expected local demo usernames.
+Check users.
 
 ```bash
 docker compose exec -T web python manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); print(list(User.objects.order_by('username').values_list('username', flat=True)))"
 ```
 
-Expected result:
+Expected:
 
 ```text
 ['admin', 'customer', 'merchant', 'ops']
 ```
 
+Shared local password for the seeded users:
+
+```text
+password123
+```
+
+Check return-case count.
+
+```bash
+docker compose exec -T web python manage.py shell -c "from returns.models import ReturnCase; print(ReturnCase.objects.count())"
+```
+
+Expected baseline:
+
+```text
+32
+```
+
 ## Public route verification
 
-Open the landing page in a browser.
+Open:
+
+- `http://127.0.0.1:8000/`
+- `http://127.0.0.1:8000/login/admin/`
+- `http://127.0.0.1:8000/login/ops/`
+- `http://127.0.0.1:8000/login/customer/`
+- `http://127.0.0.1:8000/login/merchant/`
+
+Expected behavior:
+
+- the landing page presents ReturnHub as a returns workflow product
+- each role-entry page renders successfully
+- the public shell is branded and responsive
+
+## Authenticated route verification
+
+Log in through the Django admin or shell-created sessions, then open:
+
+- `http://127.0.0.1:8000/console/admin/`
+- `http://127.0.0.1:8000/console/ops/`
+- `http://127.0.0.1:8000/console/customer/`
+- `http://127.0.0.1:8000/console/merchant/`
+
+Expected behavior:
+
+- admin sees total-case context
+- ops sees queue summary cards and queue rows
+- customer sees recent linked cases
+- merchant sees recent linked cases
+
+## Ops queue verification
+
+Open:
 
 ```text
-http://127.0.0.1:8000/
+http://127.0.0.1:8000/ops/
 ```
 
-Expected visible behaviour:
+Verify:
 
-- the page title shows ReturnHub branding
-- the landing page headline explains the returns workflow product
-- four role entry cards are visible
-- buttons exist for Admin, Ops, Customer, and Merchant
-- the layout feels branded and not like a default Django page
+- the page loads for `ops` and `admin`
+- queue filters accept `status`, `priority`, `risk_label`, `search`, and `page`
+- pagination uses a page size of `15`
+- invalid pages normalize to page `1`
+- summary counts update with filtered results
 
-Open the admin surface entry page.
+Check the API equivalent while authenticated as ops or admin:
 
 ```text
-http://127.0.0.1:8000/login/admin/
+GET /api/returns/queue/?status=submitted&priority=high&risk_label=medium&search=RH&page=1
 ```
 
-Expected visible behaviour:
+Expected response shape:
 
-- a branded page loads successfully
-- the page explains that the admin entry is reserved and branded
-- the page provides a route back to the landing page
+- top-level `count`, `next`, `previous`, `results`
+- echoed `filters`
+- `summary` with status totals
 
-Open the ops surface entry page.
+## Ops case-detail verification
+
+Pick a seeded case ID and open:
 
 ```text
-http://127.0.0.1:8000/login/ops/
+http://127.0.0.1:8000/ops/<case_id>/
 ```
 
-Expected visible behaviour:
+Verify the page renders:
 
-- a branded page loads successfully
-- the page explains that the ops entry is reserved for queue-driven work
+- case header
+- status panel
+- risk panel
+- notes panel
+- timeline
+- action panel
+- evidence list
 
-Open the customer surface entry page.
+From the action panel:
+
+- update status to an allowed next state
+- request information from customer or merchant
+- add an internal note
+
+Expected behavior:
+
+- invalid transitions are rejected
+- successful actions refresh the case view
+- status changes emit `status_updated`
+- notes emit `note_added`
+
+## Shared case-detail and upload verification
+
+Open:
 
 ```text
-http://127.0.0.1:8000/login/customer/
+http://127.0.0.1:8000/cases/<case_id>/
 ```
 
-Expected visible behaviour:
+Verify role-aware behavior:
 
-- a branded page loads successfully
-- the page explains that the customer entry is reserved for case tracking
+- ops and admin can view the case and upload either document kind
+- the owning customer can view the case and upload only `evidence`
+- the linked merchant can view the case and upload only `response`
+- unrelated customer or merchant actors should be denied
 
-Open the merchant surface entry page.
+Upload checks:
 
-```text
-http://127.0.0.1:8000/login/merchant/
+- upload a valid JPG or PDF
+- confirm the upload panel returns a local success message
+- confirm the document table refreshes in place
+- confirm a `document_uploaded` event is added
+
+Document visibility checks:
+
+- customers should only see documents marked `visible_to_customer`
+- merchants should only see documents marked `visible_to_merchant`
+- ops and admins should see all case documents
+
+## API verification
+
+Authenticate with one of the seeded users and verify the live routes.
+
+Create a case as `customer`:
+
+```http
+POST /api/returns/
+Content-Type: application/json
 ```
 
-Expected visible behaviour:
+Example payload:
 
-- a branded page loads successfully
-- the page explains that the merchant entry is reserved for linked case responses
-
-## Responsive UI check
-
-Use browser dev tools to test the landing page at smaller widths.
-
-```text
-Mobile width example: 390px
-Tablet width example: 768px
-Desktop width example: 1280px
-```
-
-Expected visible behaviour:
-
-- role cards stack cleanly at narrow widths
-- navigation remains readable
-- primary action buttons remain visible without awkward overlap
-- spacing and hierarchy stay coherent
-
-## Pagination contract verification
-
-Check the fallback for out-of-range page numbers using the shared pagination utility.
-
-```bash
-docker compose exec -T web python manage.py shell -c "from returns.models import ReturnCase; from common.pagination import paginate_queryset; print(paginate_queryset(ReturnCase.objects.order_by('id'), '999').count_line)"
-```
-
-Expected result:
-
-```text
-Showing 31-32 of 32
-```
-
-On a long-lived database with extra runbook cases, the upper bound and total may be higher while the pagination fallback behavior remains the same.
-
-Check invalid-page fallback.
-
-```bash
-docker compose exec -T web python manage.py shell -c "from returns.models import ReturnCase; from common.pagination import paginate_queryset; print(paginate_queryset(ReturnCase.objects.order_by('id'), 'banana').page_obj.number)"
-```
-
-Expected result:
-
-```text
-1
-```
-
-Check zero-page fallback.
-
-```bash
-docker compose exec -T web python manage.py shell -c "from returns.models import ReturnCase; from common.pagination import paginate_queryset; print(paginate_queryset(ReturnCase.objects.order_by('id'), '0').page_obj.number)"
-```
-
-Expected result:
-
-```text
-1
-```
-
-## Returns API and risk verification
-
-### Create a deterministic case through the real API and persist a linked `RiskScore`
-
-This uses the real `/api/returns/` create path so `RiskScore` is created through the same service-layer persistence flow as the app.
-
-```bash
-docker compose exec -T web python manage.py shell <<'PY'
-import json
-from pathlib import Path
-
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from rest_framework.test import APIClient
-
-from accounts.models import MerchantProfile
-from returns.models import RiskScore
-
-User = get_user_model()
-
-customer_group = Group.objects.get(name="Customer")
-customer_user = User.objects.filter(groups=customer_group).order_by("id").first()
-merchant = MerchantProfile.objects.order_by("id").first()
-
-if customer_user is None:
-    raise SystemExit("No seeded customer found.")
-
-if merchant is None:
-    raise SystemExit("No merchant profile found.")
-
-client = APIClient()
-client.force_authenticate(customer_user)
-
-response = client.post(
-    "/api/returns/",
-    data={
-        "merchant_id": str(merchant.pk),
-        "external_order_ref": "ORDER-RISK-API-001",
-        "item_category": "electronics",
-        "return_reason": "damaged",
-        "customer_message": "The parcel corner was crushed and the screen is black after power on.",
-        "order_value": "950.00",
-        "delivery_date": "2026-03-01",
-    },
-    format="json",
-    HTTP_HOST="localhost",
-)
-
-print("create_status_code =", response.status_code)
-
-payload = getattr(response, "data", None)
-if payload is None:
-    print(response.content.decode())
-    raise SystemExit("Case creation failed before DRF response rendering.")
-
-print(json.dumps(payload, indent=2, default=str))
-
-if response.status_code != 201:
-    raise SystemExit("Case creation failed.")
-
-case_id = str(payload["id"])
-risk_exists = RiskScore.objects.filter(case_id=case_id).exists()
-
-print("risk_exists =", risk_exists)
-
-Path("/tmp/returnhub_risk_case_id.txt").write_text(case_id, encoding="utf-8")
-Path("/tmp/returnhub_risk_customer_email.txt").write_text(customer_user.email, encoding="utf-8")
-PY
-```
-
-Expected result shape:
-
-```text
-create_status_code = 201
+```json
 {
-  "id": "<case-id>",
-  "order_reference": "ORDER-RISK-API-001",
-  "status": "submitted",
-  "priority": "medium",
-  "merchant_name": "<merchant-name>",
-  "customer_email": "<seeded-customer-email>",
+  "merchant_id": 1,
+  "external_order_ref": "RH-MANUAL-0001",
   "item_category": "electronics",
-  "return_reason": "damaged",
-  "customer_message": "The parcel corner was crushed and the screen is black after power on.",
-  "order_value": "950.00",
-  "delivery_date": "2026-03-01",
-  "risk": null,
-  "created_at": "<timestamp>",
-  "updated_at": "<timestamp>"
+  "return_reason": "damaged item",
+  "customer_message": "Screen arrived cracked.",
+  "order_value": "199.99",
+  "delivery_date": "2026-01-02"
 }
-risk_exists = True
 ```
 
-The create response may include `"risk": null` for the customer-facing caller, which is expected.
+Verify:
 
-### As ops, call `/api/returns/{id}/risk/` and confirm the structured payload returns
+- response is `201`
+- case starts at `status=submitted`
+- case starts at `priority=medium`
+- a `case_created` event exists
+- a `RiskScore` exists for the case
 
-```bash
-docker compose exec -T web python manage.py shell <<'PY'
-import json
-from pathlib import Path
-
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from rest_framework.test import APIClient
-
-User = get_user_model()
-
-case_id = Path("/tmp/returnhub_risk_case_id.txt").read_text(encoding="utf-8").strip()
-
-ops_group = Group.objects.get(name="Ops")
-ops_user = User.objects.filter(groups=ops_group).order_by("id").first()
-
-if ops_user is None:
-    raise SystemExit("No seeded ops user found.")
-
-client = APIClient()
-client.force_authenticate(ops_user)
-
-response = client.get(
-    f"/api/returns/{case_id}/risk/",
-    HTTP_HOST="localhost",
-)
-
-print("status_code =", response.status_code)
-
-payload = getattr(response, "data", None)
-if payload is None:
-    print(response.content.decode())
-    raise SystemExit("Risk detail request failed before DRF response rendering.")
-
-print(json.dumps(payload, indent=2, default=str))
-PY
-```
-
-Expected result shape:
+Check detail:
 
 ```text
-status_code = 200
+GET /api/returns/<case_id>/
+```
+
+Check status update as ops or admin:
+
+```http
+PATCH /api/returns/<case_id>/status/
+Content-Type: application/json
+```
+
+Example payload:
+
+```json
 {
-  "model_version": "retrain_baseline-logreg-v1-seed-7-rows-500",
-  "score": "<decimal-score>",
-  "label": "<low|medium|high>",
-  "reason_codes": [
-    {
-      "code": "<reason-code>",
-      "direction": "<up|down>",
-      "detail": "<human-readable-detail>"
-    }
-  ],
-  "scored_at": "<timestamp>"
+  "status": "in_review",
+  "priority": "high"
 }
 ```
 
-The exact `model_version`, `score`, `label`, `reason_codes`, and `scored_at` depend on the current active model registry and scoring output, but the response shape should match this contract.
+Check note creation:
 
-### As the owning customer, call `/api/returns/{id}/` and confirm `risk` is `null`
-
-```bash
-docker compose exec -T web python manage.py shell <<'PY'
-import json
-from pathlib import Path
-
-from django.contrib.auth import get_user_model
-from rest_framework.test import APIClient
-
-User = get_user_model()
-
-case_id = Path("/tmp/returnhub_risk_case_id.txt").read_text(encoding="utf-8").strip()
-customer_email = Path("/tmp/returnhub_risk_customer_email.txt").read_text(encoding="utf-8").strip()
-
-customer_user = User.objects.get(email=customer_email)
-
-client = APIClient()
-client.force_authenticate(customer_user)
-
-response = client.get(
-    f"/api/returns/{case_id}/",
-    HTTP_HOST="localhost",
-)
-
-print("status_code =", response.status_code)
-
-payload = getattr(response, "data", None)
-if payload is None:
-    print(response.content.decode())
-    raise SystemExit("Case detail request failed before DRF response rendering.")
-
-print(json.dumps(payload, indent=2, default=str))
-print("risk_is_null =", payload.get("risk") is None)
-PY
+```http
+POST /api/returns/<case_id>/notes/
+Content-Type: application/json
 ```
 
-Expected result shape:
+Example payload:
 
-```text
-status_code = 200
+```json
 {
-  "id": "<case-id>",
-  "order_reference": "ORDER-RISK-API-001",
-  "status": "submitted",
-  "priority": "medium",
-  "merchant_name": "<merchant-name>",
-  "customer_email": "<seeded-customer-email>",
-  "item_category": "electronics",
-  "return_reason": "damaged",
-  "customer_message": "The parcel corner was crushed and the screen is black after power on.",
-  "order_value": "950.00",
-  "delivery_date": "2026-03-01",
-  "risk": null,
-  "created_at": "<timestamp>",
-  "updated_at": "<timestamp>"
+  "body": "Customer contacted support with photo evidence pending."
 }
-risk_is_null = True
 ```
 
-### Confirm the risk endpoint returns `403` to customers
+Check documents:
 
-```bash
-docker compose exec -T web python manage.py shell <<'PY'
-from pathlib import Path
+- `GET /api/returns/<case_id>/documents/`
+- `POST /api/returns/<case_id>/documents/`
 
-from django.contrib.auth import get_user_model
-from rest_framework.test import APIClient
+Check risk:
 
-User = get_user_model()
+- `GET /api/returns/<case_id>/risk/`
 
-case_id = Path("/tmp/returnhub_risk_case_id.txt").read_text(encoding="utf-8").strip()
-customer_email = Path("/tmp/returnhub_risk_customer_email.txt").read_text(encoding="utf-8").strip()
+Expected:
 
-customer_user = User.objects.get(email=customer_email)
+- `ops` and `admin` receive risk payloads
+- `customer` and `merchant` receive `403`
 
-client = APIClient()
-client.force_authenticate(customer_user)
+Check audit export:
 
-response = client.get(
-    f"/api/returns/{case_id}/risk/",
-    HTTP_HOST="localhost",
-)
+- `GET /api/returns/<case_id>/audit-export/`
 
-print("status_code =", response.status_code)
+Expected:
 
-payload = getattr(response, "data", None)
-if payload is None:
-    print(response.content.decode())
-    raise SystemExit("Customer risk request failed before DRF response rendering.")
+- CSV response
+- case rows
+- risk rows when a score exists
+- event rows
+- document metadata rows
 
-print("response_body =", payload)
-PY
-```
-
-Expected result:
+Check analytics as ops or admin:
 
 ```text
-status_code = 403
-response_body = {'detail': 'Only ops and admins can view risk output.'}
+GET /api/analytics/returns/?from=2026-01-01&to=2026-12-31
 ```
 
-### Confirm the risk endpoint returns `403` to merchants
+Expected:
+
+- `from`
+- `to`
+- `total_cases`
+- `status_counts`
+- `priority_counts`
+
+Also verify that customers cannot access the analytics route.
+
+## ML verification
+
+Check the committed active-model registry.
 
 ```bash
-docker compose exec -T web python manage.py shell <<'PY'
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from rest_framework.test import APIClient
-
-from returns.models import ReturnCase
-
-User = get_user_model()
-
-merchant_group = Group.objects.get(name="Merchant")
-merchant_user = User.objects.filter(groups=merchant_group).order_by("id").first()
-case = ReturnCase.objects.order_by("-created_at").first()
-
-if merchant_user is None:
-    raise SystemExit("No seeded merchant user found.")
-
-if case is None:
-    raise SystemExit("No case found.")
-
-client = APIClient()
-client.force_authenticate(merchant_user)
-
-response = client.get(
-    f"/api/returns/{case.pk}/risk/",
-    HTTP_HOST="localhost",
-)
-
-print("status_code =", response.status_code)
-
-payload = getattr(response, "data", None)
-if payload is None:
-    print(response.content.decode())
-    raise SystemExit("Merchant risk request failed before DRF response rendering.")
-
-print("response_body =", payload)
-PY
+docker compose exec -T web python manage.py shell -c "from pathlib import Path; print(Path('ml/registry/model_registry.json').read_text())"
 ```
 
-Expected result:
+Expected current active model metadata:
 
-```text
-status_code = 403
-response_body = {'detail': 'Only ops and admins can view risk output.'}
-```
+- version: `retrain_baseline-logreg-v1-seed-7-rows-500`
+- model type: `logistic_regression`
+- contract version: `return-risk-sprint2-v1`
+- reason code schema version: `return-risk-reasons-sprint3-v1`
 
-## Console verification
-
-### Open `/console/ops/` and confirm the risk messaging renders above Recent Cases
+Generate a dataset:
 
 ```bash
-docker compose exec -T web python manage.py shell <<'PY'
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from django.test import Client
-
-User = get_user_model()
-
-ops_group = Group.objects.get(name="Ops")
-ops_user = User.objects.filter(groups=ops_group).order_by("id").first()
-
-if ops_user is None:
-    raise SystemExit("No seeded ops user found.")
-
-client = Client()
-client.force_login(ops_user)
-
-response = client.get("/console/ops/", HTTP_HOST="localhost")
-html = response.content.decode()
-
-risk_copy_index = html.find("controlled triage signal")
-recent_cases_index = html.find("Recent cases")
-
-print("status_code =", response.status_code)
-print("has_risk_copy =", "controlled triage signal" in html)
-print("has_ops_only_copy =", "ops only" in html)
-print("has_recent_cases =", "Recent cases" in html)
-print(
-    "risk_copy_before_recent_cases =",
-    risk_copy_index != -1 and recent_cases_index != -1 and risk_copy_index < recent_cases_index,
-)
-PY
+docker compose exec -T web python manage.py generate_training_dataset --seed 7 --rows 300
 ```
 
-Expected result:
+Expected output file:
 
 ```text
-status_code = 200
-has_risk_copy = True
-has_ops_only_copy = True
-has_recent_cases = True
-risk_copy_before_recent_cases = True
+artifacts/ml/evidence_aware_training_dataset.csv
 ```
 
-### Open the other authenticated console routes
-
-These checks confirm that the current role-based console surfaces render successfully for their seeded users.
+Train the baseline model:
 
 ```bash
-docker compose exec -T web python manage.py shell <<'PY'
-from django.contrib.auth import get_user_model
-from django.test import Client
-
-User = get_user_model()
-
-users = {
-    "admin": User.objects.get(username="admin"),
-    "customer": User.objects.get(username="customer"),
-    "merchant": User.objects.get(username="merchant"),
-}
-
-paths = {
-    "admin": "/console/admin/",
-    "customer": "/console/customer/",
-    "merchant": "/console/merchant/",
-}
-
-client = Client()
-
-for role, user in users.items():
-    client.force_login(user)
-    response = client.get(paths[role], HTTP_HOST="localhost")
-    print(role, response.status_code)
-    client.logout()
-PY
+docker compose exec -T web python manage.py train_escalation_model --seed 7 --size 500
 ```
 
-Expected result:
-
-```text
-admin 200
-customer 200
-merchant 200
-```
-
-## Documentation verification
-
-Read the API and ML docs and confirm endpoint names and registry metadata match committed code.
+Retrain through the wrapper flow:
 
 ```bash
-docker compose exec -T web python manage.py shell <<'PY'
-from pathlib import Path
-import json
-
-api_doc = Path("docs/api/returns-workflow.md").read_text(encoding="utf-8")
-ml_doc = Path("docs/ml/model-registry.md").read_text(encoding="utf-8")
-registry = json.loads(Path("ml/registry/model_registry.json").read_text(encoding="utf-8"))
-
-checks = {
-    "api_doc_has_returns_create": "POST /api/returns/" in api_doc,
-    "api_doc_has_returns_detail": "GET /api/returns/{id}/" in api_doc,
-    "api_doc_has_returns_risk": "GET /api/returns/{id}/risk/" in api_doc,
-    "api_doc_has_returns_documents": "POST /api/returns/{id}/documents/" in api_doc,
-    "api_doc_has_audit_export": "GET /api/returns/{id}/audit-export/" in api_doc,
-    "api_doc_omits_stale_analytics_endpoint": "GET /api/analytics/returns/?from=&to=" not in api_doc,
-    "ml_doc_has_registry_path": "ml/registry/model_registry.json" in ml_doc,
-    "ml_doc_has_logistic_model_type": "logistic_regression" in ml_doc,
-    "registry_version_matches": registry["active_model"]["version"].startswith("retrain_baseline-logreg-v1"),
-    "registry_model_type_matches": registry["active_model"]["model_type"] == "logistic_regression",
-    "registry_contract_matches": registry["active_model"]["contract_version"] == "return-risk-sprint2-v1",
-}
-
-for key, value in checks.items():
-    print(f"{key} = {value}")
-PY
+docker compose exec -T web python manage.py retrain_baseline_model --seed 7 --rows 500
 ```
 
-Expected result:
+Expected outputs under `ml_artifacts/`:
 
-```text
-api_doc_has_returns_create = True
-api_doc_has_returns_detail = True
-api_doc_has_returns_risk = True
-api_doc_has_returns_documents = True
-api_doc_has_audit_export = True
-api_doc_omits_stale_analytics_endpoint = True
-ml_doc_has_registry_path = True
-ml_doc_has_logistic_model_type = True
-registry_version_matches = True
-registry_model_type_matches = True
-registry_contract_matches = True
-```
+- `<model_version>.pkl`
+- `<model_version>.json`
 
-## Test verification
+## Quality gates
 
-Run the full test suite.
-
-```bash
-docker compose exec -T web pytest -q
-```
-
-Expected result shape:
-
-```text
-<all tests pass>
-```
-
-Run tests with coverage.
-
-```bash
-docker compose exec -T web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80
-```
-
-Expected result:
-
-```text
-The test suite passes and the total coverage meets or exceeds 80%.
-```
-
-## Lint and format verification
-
-Run Ruff.
-
-```bash
-docker compose exec -T web python -m ruff check .
-```
-
-Expected result:
-
-```text
-All checks passed!
-```
-
-Run Black format check.
+Run formatting check:
 
 ```bash
 docker compose exec -T web python -m black . --check
 ```
 
-Expected result shape:
-
-```text
-All done! ✨ 🍰 ✨
-<n> files would be left unchanged.
-```
-
-## Error page verification
-
-A branded 404 page should render for unknown routes when `DEBUG=False`. This is already covered by tests, but it can also be checked manually in a non-development configuration if needed.
-
-Open an unknown route.
-
-```text
-http://127.0.0.1:8000/not-a-real-page/
-```
-
-Expected visible behaviour in non-debug mode:
-
-- a branded 404 page renders
-- the page uses the shared app shell
-- the page provides a clear recovery path back to the landing page
-
-## Current definition of done checklist
-
-The local environment should be considered verified when all items below are true:
-
-- containers build and start successfully
-- migrations apply successfully
-- demo data seeds successfully
-- repeated seeding keeps the case count at `32`
-- case detail workspaces render and linked users can upload documents inline
-- public UI routes load successfully
-- authenticated console routes render successfully for seeded users
-- pagination fallback checks return expected results
-- returns API create and detail checks pass
-- risk endpoint access control behaves correctly for ops, customers, and merchants
-- API and ML docs match the committed contracts and registry metadata
-- pytest passes
-- coverage gate passes
-- Ruff passes
-- Black check passes
-
-## Clean reset procedure
-
-If local state becomes inconsistent, perform a clean reset.
-
-Stop and remove containers and volumes.
+Run lint:
 
 ```bash
-docker compose down -v
+docker compose exec -T web python -m ruff check .
 ```
 
-Expected result:
-
-```text
-Containers stop and local Postgres volume data is removed.
-```
-
-Rebuild and restart.
+Run tests:
 
 ```bash
-docker compose up --build -d
+docker compose exec -T web pytest -q
 ```
 
-Expected result:
-
-```text
-Fresh containers are created and started.
-```
-
-Reapply migrations.
+Run coverage gate:
 
 ```bash
-docker compose exec -T web python manage.py migrate --noinput
+docker compose exec -T web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 ```
 
-Expected result:
+## Convenience targets
 
-```text
-The database schema is recreated cleanly.
-```
+Equivalent Make targets:
 
-Re-seed demo data.
-
-```bash
-docker compose exec -T web python manage.py seed_demo_data
-```
-
-Expected result:
-
-```text
-Seed complete. Stable return case count: 32
-```
-
-If extra verification cases exist, the printed count may be higher. The important check is that rerunning the seed command does not create duplicate fixture rows.
-
-## Troubleshooting
-
-### `web` container exits immediately
-
-Inspect logs.
-
-```bash
-docker compose logs web
-```
-
-Expected result:
-
-```text
-Logs identify the import, dependency, or configuration issue.
-```
-
-### Database health check does not pass
-
-Inspect database logs.
-
-```bash
-docker compose logs db
-```
-
-Expected result:
-
-```text
-Logs show whether PostgreSQL startup or credentials are the issue.
-```
-
-### Django cannot connect to PostgreSQL
-
-Check that `.env` values match the Compose configuration and confirm that `POSTGRES_HOST=db`.
-
-### `APIClient` calls fail inside `manage.py shell`
-
-If a shell-based API check raises `Invalid HTTP_HOST header: 'testserver'`, rerun the request with `HTTP_HOST="localhost"` as shown in this runbook.
-
-### Tests fail after local experimentation
-
-Use the clean reset procedure, then rerun migrations, seed data, and tests.
-
-## End state
-
-At the end of this runbook, the local environment should be in a verified current-project state with:
-
-- working public pages
-- working authenticated console surfaces
-- deterministic demo data
-- passing returns and risk verification
-- documentation aligned with committed contracts
-- CI-equivalent local quality checks passing
+- `make bootstrap`
+- `make up`
+- `make down`
+- `make ps`
+- `make migrate`
+- `make test`
+- `make test-cov`
+- `make lint`
+- `make format`
+- `make format-check`
+- `make check`

--- a/docs/api/ops-queue-contract.md
+++ b/docs/api/ops-queue-contract.md
@@ -1,13 +1,9 @@
 <!-- path: docs/api/ops-queue-contract.md -->
 # Ops Queue Contract
 
-## Purpose
+This document describes the queue contract currently shared by the server-rendered ops surface at `/ops/` and the DRF queue endpoint at `/api/returns/queue/`.
 
-This contract defines the intended query, ordering, and pagination behaviour for the ReturnHub ops queue based on the current project schema. It should remain aligned with the shared service-layer contract used by any future API or server-rendered ops queue surface.
-
-## Filters
-
-Supported query parameters:
+## Supported query parameters
 
 - `status`
 - `priority`
@@ -15,7 +11,9 @@ Supported query parameters:
 - `search`
 - `page`
 
-Current status values in the project:
+## Accepted values
+
+Statuses:
 
 - `submitted`
 - `in_review`
@@ -24,49 +22,99 @@ Current status values in the project:
 - `approved`
 - `rejected`
 
-Current priority values in the project:
+Priorities:
 
 - `low`
 - `medium`
 - `high`
 - `urgent`
 
-## Ordering rules
+Risk labels:
 
-Ordering is explicit and stable, and is applied before pagination:
+- `low`
+- `medium`
+- `high`
 
-1. SLA-breached cases first
-2. Higher priority before lower priority
-3. Earlier `sla_due_at` first
-4. Earlier `created_at` first
-5. `id` as the final tiebreaker
+Unknown `risk_label` values are normalized away and do not apply a filter.
 
-## Search rules
+## Search behavior
 
-Search is applied before pagination and can match:
+`search` is trimmed and applied before pagination. It matches:
 
 - `order_reference`
-- customer name
+- customer first name
+- customer last name
 - customer email
 - merchant display name
 
-## Pagination contract
+## Ordering
 
-- query parameter: `page`
-- page size: `15`
-- missing page: page `1`
-- invalid or non-integer page: page `1`
-- page less than or equal to zero: page `1`
+The queue is built in `returns.services.queue.build_queue_queryset(...)` and ordered explicitly:
 
-## Filter preservation
+1. SLA-breached active cases first
+2. higher priority before lower priority
+3. earlier `sla_due_at`
+4. earlier `created_at`
+5. ascending `id`
 
-Pagination links must preserve all active filters except the page number itself.
+SLA breach ranking is applied only to active cases in:
+
+- `submitted`
+- `in_review`
+- `waiting_customer`
+- `waiting_merchant`
 
 ## Risk annotation
 
-Queue items read the latest persisted `RiskScore` record for each `ReturnCase` and expose:
+Queue rows do not score cases inline. They annotate each case from the latest persisted `RiskScore` record and expose:
 
 - `current_risk_score`
 - `current_risk_label`
 
-The queue does not calculate risk inline. It only consumes persisted output from the scoring workflow stored on `returns.models.RiskScore`.
+If no persisted risk score exists, those fields are `null`.
+
+## Pagination
+
+Shared queue pagination contract:
+
+- query parameter: `page`
+- page size: `15`
+- missing page: `1`
+- non-integer page: `1`
+- page `<= 0`: `1`
+- out-of-range page in the server-rendered surface resolves to the last page through shared pagination utilities
+
+Pagination links preserve active filters except for `page`.
+
+## Response shape
+
+The API queue response currently returns:
+
+- `count`
+- `next`
+- `previous`
+- `results`
+- `filters`
+- `summary`
+
+`filters` echoes:
+
+- `status`
+- `priority`
+- `risk_label`
+- `search`
+- `page`
+
+`summary` includes:
+
+- `total`
+- `submitted`
+- `waiting_customer`
+- `waiting_merchant`
+- `in_review`
+- `approved`
+- `rejected`
+
+## Access control
+
+Only authenticated ops and admin users may access the queue API or the `/ops/` queue surface.

--- a/docs/api/returns-workflow.md
+++ b/docs/api/returns-workflow.md
@@ -1,54 +1,214 @@
 <!-- path: docs/api/returns-workflow.md -->
-# ReturnHub Returns Workflow API
+# Returns Workflow API
 
-This document describes the current return workflow API for case creation, triage, evidence upload, risk access, and audit export.
+This document describes the return-case API behavior implemented in the current repository.
 
-## Endpoints
+## Runtime routes
+
+The live application exposes these routes:
+
+- `POST /api/returns/`
+- `GET /api/returns/{case_id}/`
+- `PATCH /api/returns/{case_id}/status/`
+- `POST /api/returns/{case_id}/notes/`
+- `GET /api/returns/queue/`
+- `GET /api/returns/{case_id}/documents/`
+- `POST /api/returns/{case_id}/documents/`
+- `GET /api/returns/{case_id}/risk/`
+- `GET /api/returns/{case_id}/audit-export/`
+
+The repository also contains compatibility wrappers in `api/` and canonical route modules in `returns/api/`; both are aligned around the same workflow services.
+
+## Create case
 
 `POST /api/returns/`
 
-Creates a return case for the authenticated customer. The request is validated by DRF serializers and persisted through the service layer. Creation emits a `case_created` audit event and persists risk output through the scoring service.
+Current request fields:
 
-`GET /api/returns/{id}/`
+- `merchant_id`
+- `external_order_ref`
+- `item_category`
+- `return_reason`
+- `customer_message`
+- `order_value`
+- `delivery_date`
 
-Returns case detail for the permitted actor. Customers can view only their own cases. Merchants can view only cases tied to their merchant profile. Ops and admins can view all cases.
+Rules:
 
-`PATCH /api/returns/{id}/status/`
+- only authenticated customers and admins may create cases
+- `order_value` must be greater than zero
+- `delivery_date` cannot be in the future
+- `customer_message` cannot be blank after trimming
 
-Ops and admins can change case status and optional priority through validated service-layer transitions.
-
-`POST /api/returns/{id}/notes/`
-
-Ops and admins can append internal notes. Each note creation emits a `note_added` audit event.
-
-`GET /api/returns/{id}/documents/`
-
-Lists documents visible to the requesting actor under current case-level visibility rules.
-
-`POST /api/returns/{id}/documents/`
-
-Uploads an evidence or response document through the document service, emits a `document_uploaded` event, and triggers a best-effort risk rescore.
-
-`GET /api/returns/{id}/risk/`
-
-Ops and admins can retrieve persisted risk output. Customers and merchants do not receive this payload.
-
-`GET /api/returns/{id}/audit-export/`
-
-Exports case metadata, event history, document metadata, and the latest risk summary as CSV when the audit-export view is enabled.
-
-## Workflow rules
-
-Case creation always starts with deterministic defaults:
+Current defaults on create:
 
 - `status = submitted`
 - `priority = medium`
 
-Status transitions are validated centrally in the service layer. Views do not mutate model state directly.
+Side effects:
 
-## Audit behaviour
+- SLA fields are refreshed
+- `case_created` audit event is emitted
+- risk is scored and persisted
 
-The workflow emits append-only `CaseEvent` rows for:
+## Retrieve case detail
+
+`GET /api/returns/{case_id}/`
+
+Access rules:
+
+- ops and admins can view any case
+- customers can view only their own cases
+- merchants can view only cases tied to their merchant profile
+
+Response includes:
+
+- core case fields
+- embedded document metadata
+- `risk`
+- `latest_risk`
+
+Risk visibility in the detail serializer:
+
+- ops/admin: populated when a `RiskScore` exists
+- customer/merchant: `null`
+
+## Update status
+
+`PATCH /api/returns/{case_id}/status/`
+
+Allowed for:
+
+- ops
+- admin
+
+Request fields:
+
+- `status`
+- `priority` optional
+
+Allowed status transitions:
+
+- `submitted -> in_review | waiting_customer | waiting_merchant | approved | rejected`
+- `in_review -> waiting_customer | waiting_merchant | approved | rejected`
+- `waiting_customer -> in_review | approved | rejected`
+- `waiting_merchant -> in_review | approved | rejected`
+- `approved ->` no further transitions
+- `rejected ->` no further transitions
+
+Side effects:
+
+- `last_status_changed_at` is updated
+- SLA fields are refreshed
+- optional priority update is persisted
+- `status_updated` audit event is emitted
+- risk is rescored and persisted
+
+## Add note
+
+`POST /api/returns/{case_id}/notes/`
+
+Allowed for:
+
+- ops
+- admin
+
+Request field:
+
+- `body`
+
+Rules:
+
+- body cannot be blank after trimming
+
+Side effect:
+
+- `note_added` audit event is emitted
+
+## Queue
+
+`GET /api/returns/queue/`
+
+Allowed for:
+
+- ops
+- admin
+
+Supports:
+
+- filtering by `status`, `priority`, `risk_label`, `search`, `page`
+- explicit ordering
+- shared pagination
+- summary counts
+
+See `docs/api/ops-queue-contract.md` for the full queue contract.
+
+## Documents
+
+`GET /api/returns/{case_id}/documents/`
+
+Returns documents visible to the requesting actor.
+
+Visibility rules:
+
+- ops/admin see all documents
+- owning customer sees only documents with `visible_to_customer=True`
+- linked merchant sees only documents with `visible_to_merchant=True`
+
+`POST /api/returns/{case_id}/documents/`
+
+Upload rules:
+
+- customers can upload only `evidence` to their own cases
+- merchants can upload only `response` to their own cases
+- ops/admin can upload either document kind
+
+Side effects:
+
+- `EvidenceDocument` metadata is persisted
+- `document_uploaded` audit event is emitted
+- best-effort rescoring runs after upload
+
+Visibility defaults:
+
+- `evidence` defaults to customer-visible and merchant-hidden
+- `response` defaults to merchant-visible and customer-hidden
+
+## Risk
+
+`GET /api/returns/{case_id}/risk/`
+
+Allowed for:
+
+- ops
+- admin
+
+Behavior:
+
+- returns persisted `RiskScore`
+- returns `404` when no score exists yet
+- returns `403` for customers and merchants
+
+Current response fields:
+
+- `model_version`
+- `score`
+- `label`
+- `reason_codes`
+- `scored_at`
+
+## Audit export
+
+`GET /api/returns/{case_id}/audit-export/`
+
+Returns CSV export content for an accessible case, including:
+
+- case metadata rows
+- latest risk rows when present
+- event history rows
+- document metadata rows
+
+## Audit events emitted today
 
 - `case_created`
 - `status_updated`
@@ -56,6 +216,6 @@ The workflow emits append-only `CaseEvent` rows for:
 - `document_uploaded`
 - `risk_scored`
 
-## Risk visibility
+Seeded demo data also emits:
 
-Risk output is intentionally limited to ops and admin users. It is designed as a triage signal and not a customer-facing decision artefact.
+- `seed_case_created`

--- a/docs/ml/baseline-escalation-risk.md
+++ b/docs/ml/baseline-escalation-risk.md
@@ -1,75 +1,99 @@
 <!-- path: docs/ml/baseline-escalation-risk.md -->
-# Baseline Escalation Risk Model
+# Baseline Escalation Risk
 
-## Purpose
+This document describes the ML flow currently implemented for return-case escalation scoring.
 
-ReturnHub now has a seeded baseline training flow plus a retraining wrapper for the evidence-aware feature path. The implementation is deterministic so repeated runs with the same seed and row count produce stable training data and model metadata.
+## Current approach
 
-## Training inputs
+The project uses a logistic-regression baseline with:
 
-The baseline trainer and inference path share the committed feature contract in `ml/contracts/return_case_features.json`. The current feature set includes:
+- deterministic synthetic training data
+- a committed feature contract
+- versioned pickle and metadata artifacts
+- a committed active-model registry
+- persisted `RiskScore` records on return cases
 
-- item category code
-- delivery-to-return days
-- return reason code
-- damaged-return indicator
-- customer message length bucket
-- prior returns count
-- order value band
-- high order-value indicator
-- customer evidence count
-- hours to first customer evidence
-- merchant document count
+## Feature contract
 
-These features are defined and encoded by:
+Training and inference share the feature contract in:
 
 - `ml/contracts/return_case_features.json`
 - `ml/features.py`
 
-## Data stance
+The current implementation includes signals derived from:
 
-Training data is synthetic and deterministic. The training rows are generated
-from a random seed in `ml/training/baseline.py`, so repeated runs with the same
-inputs produce the same feature rows and labels. `ml/training/train.py` wraps the same trainer and writes a retrain-prefixed model version when the retrain command is used.
+- item category
+- delivery-to-return timing
+- return reason
+- customer message length
+- prior returns history
+- order-value buckets
+- customer evidence activity
+- merchant document activity
 
-No external dataset is required for the baseline training flow.
+## Training data
 
-## Model choice
+Training data is synthetic and deterministic.
 
-The current baseline trainer uses:
+Current dataset flows:
 
-- `DictVectorizer`
-- `LogisticRegression`
-- seed-controlled synthetic row generation
+- `ml/datasets/synthetic.py` generates seeded rows
+- `ml/datasets/dataset.py` exposes the dataset wrapper
+- `ml/management/commands/generate_training_dataset.py` writes CSV output
 
-The trained artefact is saved as a versioned `.pkl` file.
+Default dataset export command:
 
-## Current implementation notes
+```bash
+docker compose exec -T web python manage.py generate_training_dataset --seed 7 --rows 300
+```
 
-- The baseline trainer is exposed as a Python function and through Django
-  management commands.
-- The core training function is `train_and_save_baseline_model(...)` in
-  `ml/training/baseline.py`.
-- The standard training command is
-  `ml/management/commands/train_escalation_model.py`.
-- The retrain command is `ml/management/commands/retrain_baseline_model.py`.
-- The dataset export command is
-  `ml/management/commands/generate_training_dataset.py`.
-- The trainer computes a SHA-256 hash of the committed feature contract file and
-  stores it in the training metadata.
-- `scikit-learn` is imported inside the training function, so importing the
-  module itself does not require `sklearn` to be installed.
-- Executing training still requires `scikit-learn` to be available in the
-  runtime environment.
+Default output path:
 
-## Artefact outputs
+```text
+artifacts/ml/evidence_aware_training_dataset.csv
+```
 
-Running baseline training writes:
+## Training commands
 
-- model artefact file: `<model_version>.pkl`
-- metadata file: `<model_version>.json`
+Baseline training:
 
-The metadata currently includes:
+```bash
+docker compose exec -T web python manage.py train_escalation_model --seed 7 --size 500
+```
+
+Retraining wrapper:
+
+```bash
+docker compose exec -T web python manage.py retrain_baseline_model --seed 7 --rows 500
+```
+
+Current committed active version:
+
+```text
+retrain_baseline-logreg-v1-seed-7-rows-500
+```
+
+## Artifact layout
+
+Training writes versioned artifacts under:
+
+```text
+ml_artifacts/
+```
+
+Per model version:
+
+- `<model_version>.pkl`
+- `<model_version>.json`
+
+Committed example artifacts currently present:
+
+- `ml_artifacts/retrain_baseline-logreg-v1-seed-7-rows-500.pkl`
+- `ml_artifacts/retrain_baseline-logreg-v1-seed-7-rows-500.json`
+
+## Metadata contract
+
+Training metadata currently includes:
 
 - `model_version`
 - `feature_contract_version`
@@ -80,93 +104,55 @@ The metadata currently includes:
 - `metrics`
 - `trained_at`
 
-## Registry behavior
+The inference path requires `feature_contract_hash` to be present in metadata.
 
-The management command updates the committed active-model registry after a
-successful training run.
+## Inference flow
 
-The command writes the active model entry to:
+Runtime scoring path:
 
-- `ml/registry/model_registry.json`
+1. `returns/services/risk.py` requests a scoring result.
+2. `ml/services/scoring.py` loads the active registry entry and artifacts.
+3. `ml/features.extract_case_features(...)` builds the feature vector.
+4. The model returns a probability.
+5. The score is quantized to two decimal places.
+6. Labels are mapped with current thresholds:
+   - `>= 0.75` -> `high`
+   - `>= 0.45` -> `medium`
+   - otherwise -> `low`
+7. Reason codes are generated from the feature vector.
+8. The result is persisted as `RiskScore`.
 
-The current registry contract stores a single `active_model` object with:
+If the active artifact cannot be loaded safely, scoring falls back to the placeholder scorer in `ml/scoring.py`.
 
-- `version`
-- `model_type`
-- `contract_version`
-- `reason_code_schema_version`
-- `status`
+## Risk persistence
 
-Related file locations:
+The returns domain stores one `RiskScore` per case and updates that row on rescore.
 
-- training module: `ml/training/baseline.py`
-- training wrapper: `ml/training/train.py`
-- dataset wrapper: `ml/datasets/dataset.py`
-- training command: `ml/management/commands/train_escalation_model.py`
-- retrain command: `ml/management/commands/retrain_baseline_model.py`
-- dataset export command: `ml/management/commands/generate_training_dataset.py`
-- registry service: `ml/services/model_registry.py`
-- active model registry: `ml/registry/model_registry.json`
+Rescoring currently happens on:
 
-## How to run it currently
+- case creation
+- status update
+- document upload
 
-The baseline trainer can now be run through Django management commands.
+Each rescore emits a `risk_scored` audit event.
 
-Example:
+## Dependencies
 
-```bash
-python manage.py train_escalation_model --seed 7 --size 500
-```
+ML-related runtime packages currently listed in the repository:
 
-Docker equivalent:
-
-```bash
-docker compose exec -T web python manage.py train_escalation_model --seed 7 --size 500
-```
-
-Retrain wrapper example:
-
-```bash
-docker compose exec -T web python manage.py retrain_baseline_model --seed 7 --rows 500
-```
-
-Dataset export example:
-
-```bash
-docker compose exec -T web python manage.py generate_training_dataset --seed 7 --rows 300
-```
-
-The command:
-
-- trains the baseline model
-- writes the model artefact and metadata to the configured output directory
-- registers the trained model as the active model in
-  `ml/registry/model_registry.json`
-
-The retrain command registers a retrain-prefixed version such as
-`retrain_baseline-logreg-v1-seed-7-rows-500`.
-
-The trainer is also still available as an importable Python function. A minimal
-invocation looks like this:
-
-```bash
-python -c "from pathlib import Path; from ml.training.baseline import train_and_save_baseline_model; print(train_and_save_baseline_model(Path('tmp/ml_artifacts')))"
-```
+- `pandas`
+- `scikit-learn`
+- `joblib`
 
 ## Test coverage
 
-Baseline training coverage currently lives in:
+Relevant tests currently cover training, scoring, registry access, artifacts, features, and dataset generation, including:
 
 - `tests/test_baseline_training.py`
 - `tests/test_ml_training.py`
 - `tests/test_ml_management_commands.py`
-
-Those tests validate:
-
-- synthetic row reproducibility
-- seed sensitivity
-- metadata shape
-- stable metadata for repeated runs with the same inputs
-
-Training-dependent test cases skip cleanly when `sklearn` is unavailable in the
-runtime container.
+- `tests/test_model_registry.py`
+- `tests/test_artifact_scoring.py`
+- `tests/test_feature_contract.py`
+- `tests/test_ml_feature_extraction.py`
+- `tests/test_risk_dataset_generation.py`

--- a/docs/ml/model-registry.md
+++ b/docs/ml/model-registry.md
@@ -1,40 +1,75 @@
 <!-- path: docs/ml/model-registry.md -->
-# ReturnHub Model Registry
+# Model Registry
 
-ReturnHub uses a committed model registry so scoring can resolve the active model version and validate contract metadata consistently.
+ReturnHub uses a committed JSON registry to point scoring and operational workflows at one active model version.
 
 ## Registry file
 
-`ml/registry/model_registry.json`
+Path:
 
-The active entry includes:
+```text
+ml/registry/model_registry.json
+```
 
-- `version`
-- `model_type`
-- `contract_version`
-- `reason_code_schema_version`
-- `status`
+Current structure:
 
-## Active model entry
+```json
+{
+  "active_model": {
+    "contract_version": "return-risk-sprint2-v1",
+    "model_type": "logistic_regression",
+    "reason_code_schema_version": "return-risk-reasons-sprint3-v1",
+    "status": "active",
+    "version": "retrain_baseline-logreg-v1-seed-7-rows-500"
+  }
+}
+```
 
-The current active entry is artifact-backed and points at a logistic-regression baseline, for example `retrain_baseline-logreg-v1-seed-7-rows-500` with `model_type = logistic_regression`.
+## Current active model
 
-This entry exists so the application can:
+- version: `retrain_baseline-logreg-v1-seed-7-rows-500`
+- model type: `logistic_regression`
+- contract version: `return-risk-sprint2-v1`
+- reason code schema version: `return-risk-reasons-sprint3-v1`
+- status: `active`
 
-- persist a stable `RiskScore`
-- attach a model version to predictions
-- enforce feature contract continuity
-- expose structured reason codes to ops users
-- preserve one explicit model pointer for inference and retraining workflows
+## How the registry is used
 
-## Contract boundaries
+The scoring path in `ml/services/scoring.py`:
 
-The registry entry must remain compatible with:
+- loads the active registry entry
+- resolves the expected `.pkl` artifact under `ml_artifacts/`
+- resolves the matching metadata `.json`
+- rejects loading when the registry, artifact, or metadata is missing or invalid
+
+The returns risk service then uses that scoring result to persist `returns.models.RiskScore`.
+
+## Registry boundaries
+
+The active entry must remain compatible with:
 
 - `ml/contracts/return_case_features.json`
+- `ml/features.py`
 - `ml/reason_codes.py`
 - `ml/services/model_registry.py`
 - `ml/services/scoring.py`
 - `returns/services/risk.py`
 
-Updating the active model version should not require changes to the API field names or `RiskScore` persistence shape.
+## Update paths
+
+The registry is updated by these commands:
+
+- `python manage.py train_escalation_model --seed 7 --size 500`
+- `python manage.py retrain_baseline_model --seed 7 --rows 500`
+
+The standard training command writes an active entry from `train_and_save_baseline_model(...)`.
+
+The retrain wrapper writes an active entry from `ml.training.train.train_and_persist(...)`.
+
+## Operational expectation
+
+Changing the active registry entry should not require API shape changes. The application expects the active model to preserve:
+
+- persisted `RiskScore` fields
+- reason-code schema compatibility
+- the committed feature-contract boundary

--- a/docs/ui/design-system.md
+++ b/docs/ui/design-system.md
@@ -1,22 +1,91 @@
-# path: docs/ui/design-system.md
-# ReturnHub design system foundation
+# ReturnHub Design System
 
-## Tone
+This document describes the design-system baseline currently represented by the templates and styles in `static/css/tokens.css`, `static/css/app.css`, and the shared template partials.
 
-Use a retail-operations style that feels quiet, reliable, and clear. The interface should favour legibility over decoration and trust over novelty.
+## Product tone
 
-## Core tokens
+The UI should feel:
 
-Surface colours should distinguish page background, cards, and muted support areas. Accent colour should be used for primary action and active navigation. Success, warning, and danger colours should be semantic and reserved for state communication.
+- operational
+- clear
+- trustworthy
+- calm under dense workflow content
 
-Typography should use a restrained scale with clear heading, section, body, and helper text sizes. Cards should use soft borders, moderate radius, and restrained elevation. Dense tables should prioritise scan speed and row separation.
+The codebase currently favors a server-rendered application shell with reusable partials over isolated one-off page designs.
 
-## Component direction
+## Surface types
 
-Navigation should remain slim and readable. Status pills should be compact and semantically coloured. Empty states should provide context plus one sensible next step. Flash messages should appear near the top of the content region and should not shift layout aggressively. Case-local upload success and validation states may also render inside the upload panel when only one section of the page is refreshed.
+The current UI system supports three surface families:
 
-Shared partials should carry repeated markup for console hero shells, recent-case cards, visual timelines, document tables, risk summaries, upload panels, and form errors so role-specific templates do not duplicate structure.
+- public marketing and role-entry pages
+- authenticated role dashboards
+- workflow pages for ops queue, ops case detail, and shared case detail
 
-## Responsive rules
+## Shared shell expectations
 
-Public surfaces should stack cleanly on mobile while preserving primary actions above the fold. Multi-column layouts should collapse into one column without losing heading hierarchy or action clarity.
+The application shell is expected to provide:
+
+- consistent ReturnHub branding
+- predictable page titles
+- top-level navigation
+- flash-message placement near the top of content
+- responsive content width and spacing
+
+Template-level shell metadata is provided by `common.context_processors.app_shell`.
+
+## Reusable components in the repository
+
+Current shared partials include patterns for:
+
+- app navigation
+- console hero shell
+- recent-case cards
+- queue summary cards
+- queue and filter bars
+- status badges
+- risk badges
+- risk summary panels
+- document tables
+- upload panels
+- notes panels
+- note lists and forms
+- timelines
+- empty states
+- pagination
+- request-info panels
+
+Ops-specific partials mirror those same patterns for the dedicated `/ops/` surfaces.
+
+## Data-density rules
+
+The current product surface is intentionally table- and panel-oriented. Design decisions should preserve:
+
+- fast scanning in queue tables
+- visible status and priority signals
+- stable placement for notes, events, and documents
+- local success and validation feedback instead of global page disruption
+
+## State styling rules
+
+- status pills and badges should carry semantic meaning but remain compact
+- risk should always be visible as a dedicated panel on ops-facing case detail
+- success and validation feedback for uploads should stay in the upload panel
+- empty states should explain the absence of data and the next likely action
+
+## Responsive behavior
+
+Current templates are expected to:
+
+- stack multi-column layouts on smaller screens
+- keep queue and document tables readable through overflow handling rather than over-compression
+- preserve visible headings, action buttons, and status context on mobile widths
+
+## Accessibility baseline
+
+Documentation and templates should continue to assume:
+
+- semantic headings
+- visible focus states
+- readable color contrast
+- keyboard-accessible actions
+- text labels instead of color-only meaning

--- a/docs/ui/evidence-states.md
+++ b/docs/ui/evidence-states.md
@@ -1,40 +1,96 @@
 <!-- path: docs/ui/evidence-states.md -->
-# Evidence UI states
+# Evidence States
 
-Sprint 4 introduces evidence as a reusable product surface. The UI should feel calm, operational, and trustworthy rather than like a generic file-upload widget.
+This document describes the document and evidence behavior currently implemented around the shared case detail page and the returns document APIs.
 
-## Primary components
+## Current surfaces
 
-The evidence workspace currently relies on five core components:
+Evidence-related UI appears in:
+
+- `/cases/{case_id}/`
+- `/ops/{case_id}/`
+- `GET /api/returns/{case_id}/documents/`
+- `POST /api/returns/{case_id}/documents/`
+
+## Current components
+
+The repository currently uses these evidence-oriented components:
 
 - document table
 - upload panel
-- risk summary
+- risk panel
 - timeline
-- form errors
+- form error rendering
 
-## State expectations
+## Empty state
 
-### Empty evidence state
+When no documents are visible for a case:
 
-Use a bordered empty panel with a concise explanation. Do not render empty tables. The message should explain that documents uploaded by customers, merchants, or ops will appear here in created order.
+- the page should render a stable empty state
+- the document region should not collapse awkwardly
+- copy should make it clear that uploads from permitted actors will appear here
 
-### Upload validation state
+## Upload success state
 
-Keep validation feedback local to the upload panel. Errors should use semantic alert styling and identify the field causing the problem.
+Server-rendered uploads on `/cases/{case_id}/documents/upload/` currently:
 
-### Success state
+- submit the form asynchronously
+- return JSON containing refreshed `upload_panel_html`
+- return JSON containing refreshed `document_table_html`
+- keep the success message local to the upload panel
 
-Keep the success message local to the upload panel and refresh the document table in place. The current case detail page submits the upload form with `fetch(...)` and swaps only the upload panel and document table fragments from the JSON response.
+Expected success copy in the current flow:
 
-### Forbidden state
+```text
+Document uploaded successfully.
+```
 
-If a customer or merchant does not own the case, the GET case workspace should return `403`. If the authenticated actor lacks an upload-capable role but is otherwise allowed to view the page, render the workspace without the upload form and show an “Actor role unavailable” fallback in the panel. Unauthorized upload POST requests should return `403` with refreshed panel HTML, not a generic server error.
+## Validation and workflow-error state
 
-### No-risk state
+If form validation fails or the document service rejects the upload:
 
-Cases without a risk score should still show the risk panel. Render “No score yet” with explanatory supporting copy so the layout remains stable.
+- the upload panel is re-rendered with local errors
+- the surrounding page shell remains intact
+- the response uses `400`
 
-## Responsive notes
+## Forbidden state
 
-The evidence page must stack to a single column on smaller breakpoints. The risk panel should become full width. Tables should retain readability through horizontal scrolling rather than compressing columns into illegible text.
+Current forbidden behaviors:
+
+- unrelated customers or merchants cannot access another actor's case data
+- upload attempts without a valid actor role return `403`
+- customers can only upload `evidence`
+- merchants can only upload `response`
+
+For the API routes, permission failures also return `403` with a structured error payload.
+
+## Visibility state
+
+Document visibility is role-aware:
+
+- ops and admins see all documents for the case
+- customers see only documents with `visible_to_customer=True`
+- merchants see only documents with `visible_to_merchant=True`
+
+Default visibility on upload:
+
+- `evidence`: customer-visible, merchant-hidden
+- `response`: merchant-visible, customer-hidden
+
+## Risk-adjacent state
+
+Evidence uploads trigger a best-effort rescore. On ops-facing surfaces, the risk panel should remain present even when no persisted score exists yet.
+
+Fallback copy expectation:
+
+```text
+No score yet
+```
+
+## Responsive behavior
+
+Evidence-related layouts should continue to:
+
+- stack to one column on narrow screens
+- preserve upload controls and error visibility
+- allow document tables to scroll horizontally when needed

--- a/docs/ui/product-ui-brief.md
+++ b/docs/ui/product-ui-brief.md
@@ -1,22 +1,89 @@
-# path: docs/ui/product-ui-brief.md
-# ReturnHub product UI brief
+# ReturnHub Product UI Brief
 
-ReturnHub should feel calm, capable, and operational from the first click. The public landing page should position the product as a returns workflow system for retail operations rather than a developer demo. Copy should be direct, practical, and trustworthy.
+This brief reflects the product surfaces that currently exist in the repository.
 
-The visual tone should avoid heavy gradients, novelty dashboards, or crowded metric walls. Surfaces should feel structured and deliberate, with clear hierarchy between summary content, next actions, and supporting detail.
+## Product stance
 
-## Primary audiences
+ReturnHub is not just an API demo. The shipped UI already exposes role-aware workflow surfaces for public entry, dashboards, triage, and case review. The design goal is to make return operations legible without hiding the shared service-layer behavior underneath.
 
-The first public surface has four immediate audiences. Admin users need platform management entry. Ops users need queue and triage entry. Customers need a simple way to track and support their own return cases. Merchants need a role-specific surface for response handling.
+## Current audiences
 
-## Page hierarchy
+The repository currently serves four product audiences:
 
-The landing page should open with product framing, one concise supporting sentence, and four role entry actions. Below that, the page should explain the workflow in a few operational steps and show product principles such as auditability, predictable case handling, and clear ownership boundaries.
+- admins
+- ops users
+- customers
+- merchants
 
-## Reusable shell expectations
+## Current route map
 
-Every future authenticated surface should inherit a consistent shell with a top navigation area, alert region, constrained content width, and predictable spacing. Dense tables, status pills, empty states, pagination, document tables, upload panels, timeline panels, and hero shells should be reusable components rather than one-off template fragments.
+Public:
 
-## Accessibility expectations
+- `/`
+- `/login/admin/`
+- `/login/ops/`
+- `/login/customer/`
+- `/login/merchant/`
 
-Colour contrast must remain readable in light mode. Focus states must be visible. Semantic headings and list markup should be used consistently. Actions must be reachable by keyboard. Decorative visuals should never carry exclusive meaning.
+Authenticated dashboards:
+
+- `/console/admin/`
+- `/console/ops/`
+- `/console/customer/`
+- `/console/merchant/`
+
+Workflow pages:
+
+- `/ops/`
+- `/ops/{case_id}/`
+- `/cases/{case_id}/`
+
+## Surface intent by audience
+
+Admin:
+
+- monitor overall system activity through the admin console shell
+- retain access to Django admin for low-level administration
+
+Ops:
+
+- work from a prioritized queue
+- inspect risk, notes, events, and evidence in one case-detail workspace
+- update status, request information, and add internal notes inline
+
+Customer:
+
+- access only their own cases
+- view case detail and visible documents
+- upload evidence to their own cases
+
+Merchant:
+
+- access only merchant-linked cases
+- review shared workflow context
+- upload response documents to linked cases
+
+## Current UI priorities
+
+The current repository emphasizes:
+
+- clear route boundaries by role
+- reusable shell structure across pages
+- workflow-first layouts over decorative dashboards
+- inline partial refresh for ops actions and document uploads
+- stable presentation of audit history, evidence, and risk
+
+## UX constraints from current implementation
+
+- risk is intentionally hidden from customer and merchant detail payloads
+- document upload options depend on actor role
+- ops queue and case detail must stay useful under dense operational data
+- error states should return branded pages or local panel-level validation instead of raw framework output where possible
+
+## Near-term documentation baseline
+
+Any future UI documentation should continue to treat these implemented surfaces as the source of truth:
+
+- landing and role-entry pages are real product routes, not placeholders in the docs
+- `/ops/` and `/ops/{case_id}/` are the main ops workflow surfaces
+- `/cases/{case_id}/` is the shared role-aware case workspace


### PR DESCRIPTION
## Summary

Refreshes Sprint 5 documentation so it matches the current ReturnHub implementation, especially the ops queue, ops case detail workflow, and console-based verification flow.

## Changes

- regenerated `RUNBOOK.md` to reflect the current app state
- updated setup, route, workflow, API, ML, and quality-gate documentation
- corrected ops verification steps to match the real `ops:case-detail` action flow
- replaced outdated proof snippets with repo-accurate console verification commands
- tightened proof commands to suppress expected `400`/`403` trace noise using:
  - `Client(HTTP_HOST='localhost', raise_request_exception=False)`
  - `logging.getLogger('django.request').disabled = True`

## Why

The previous runbook and proof commands had drifted from the current codebase in several places, including route usage, model imports, related names, and expected event types. This update brings the docs back in sync with the implementation so contributors and external readers can use the documented commands without hitting avoidable mismatches.

## Validation

- reviewed the current routes, views, services, models, templates, and tests
- regenerated and checked proof commands against the current repo behavior
- confirmed expected outcomes from the attached verification screenshots:
  - queue verification
  - case-detail verification
  - workflow action verification
  - layout verification
  - day 5 ops surface verification
  - compact console verification

## Result

The runbook now accurately documents the current Sprint 5 implementation and includes proof commands that run cleanly, produce meaningful boolean checks, and avoid noisy expected error traces in the console.

## Notes

- this PR is documentation-focused
- no application logic was changed
- proof screenshots reflect expected passing outcomes for the updated commands