### PR TITLE
Feat/implement console pages for all roles

### DIFF
--- a/accounts/views_console.py
+++ b/accounts/views_console.py
@@ -2,8 +2,14 @@
 
 from console.views import (
     AdminConsoleView as BaseAdminConsoleView,
+)
+from console.views import (
     CustomerConsoleView as BaseCustomerConsoleView,
+)
+from console.views import (
     MerchantConsoleView as BaseMerchantConsoleView,
+)
+from console.views import (
     OpsConsoleView as BaseOpsConsoleView,
 )
 

--- a/accounts/views_console.py
+++ b/accounts/views_console.py
@@ -1,11 +1,28 @@
-"""Compatibility console views exposed through the accounts app."""
+"""Console landing views for each ReturnHub surface."""
 
 from console.views import (
-    AdminConsoleView,
-    CustomerConsoleView,
-    MerchantConsoleView,
-    OpsConsoleView,
+    AdminConsoleView as BaseAdminConsoleView,
+    CustomerConsoleView as BaseCustomerConsoleView,
+    MerchantConsoleView as BaseMerchantConsoleView,
+    OpsConsoleView as BaseOpsConsoleView,
 )
+
+
+class AdminConsoleView(BaseAdminConsoleView):
+    """Admin console entry page."""
+
+
+class OpsConsoleView(BaseOpsConsoleView):
+    """Ops console entry page."""
+
+
+class CustomerConsoleView(BaseCustomerConsoleView):
+    """Customer console entry page."""
+
+
+class MerchantConsoleView(BaseMerchantConsoleView):
+    """Merchant console entry page."""
+
 
 __all__ = [
     "AdminConsoleView",

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -170,6 +170,183 @@ button:focus-visible {
   backdrop-filter: blur(12px);
 }
 
+.rh-auth-shell {
+  max-width: 76rem;
+  margin: 0 auto;
+}
+
+.rh-auth-frame {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(24rem, 0.88fr);
+  gap: calc(var(--rh-space-6) + var(--rh-space-1));
+  align-items: stretch;
+}
+
+.rh-auth-aside {
+  padding: calc(var(--rh-space-7) - 0.25rem) calc(var(--rh-space-6) + 0.25rem);
+  border-radius: var(--rh-radius-xl);
+  background:
+    linear-gradient(160deg, rgba(255, 252, 247, 0.96) 0%, rgba(244, 247, 241, 0.94) 100%);
+  border: 1px solid rgba(27, 35, 28, 0.08);
+  box-shadow: var(--rh-shadow-lg);
+}
+
+.rh-auth-aside h1 {
+  font-family: var(--rh-font-family-display);
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  line-height: 0.96;
+  letter-spacing: -0.03em;
+  margin-bottom: 1rem;
+  max-width: 9ch;
+}
+
+.rh-auth-lead {
+  max-width: 34rem;
+  color: var(--rh-color-text-muted);
+  font-size: 1.04rem;
+  margin-bottom: var(--rh-space-5);
+}
+
+.rh-auth-trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-bottom: var(--rh-space-5);
+}
+
+.rh-auth-surface-links {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: var(--rh-space-5);
+}
+
+.rh-auth-surface-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 52px;
+  padding: 0.9rem 1rem;
+  border-radius: 1.1rem;
+  background: rgba(255, 251, 245, 0.72);
+  border: 1px solid rgba(27, 35, 28, 0.08);
+  color: var(--rh-color-text);
+  text-decoration: none;
+  font-weight: 700;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.rh-auth-surface-link::after {
+  content: "Open";
+  color: var(--rh-color-text-muted);
+  font-size: var(--rh-font-size-xs);
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.rh-auth-surface-link:hover,
+.rh-auth-surface-link:focus-visible,
+.rh-auth-surface-link.is-active {
+  background: rgba(247, 243, 235, 0.95);
+  border-color: rgba(31, 90, 67, 0.24);
+  color: var(--rh-color-accent-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(23, 34, 28, 0.1);
+}
+
+.rh-auth-note {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.2rem;
+  background: rgba(31, 90, 67, 0.06);
+  border: 1px solid rgba(31, 90, 67, 0.12);
+}
+
+.rh-auth-note strong {
+  font-size: var(--rh-font-size-sm);
+}
+
+.rh-auth-note span {
+  color: var(--rh-color-text-muted);
+  font-size: var(--rh-font-size-sm);
+}
+
+.rh-auth-card {
+  overflow: hidden;
+}
+
+.rh-auth-card__topbar {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(27, 35, 28, 0.08);
+  background: rgba(255, 250, 243, 0.84);
+  align-items: center;
+}
+
+.rh-auth-card__body {
+  padding: calc(var(--rh-space-6) + 0.15rem);
+}
+
+.rh-auth-card .form-label {
+  color: var(--rh-color-text);
+  font-size: var(--rh-font-size-sm);
+  font-weight: 700;
+}
+
+.rh-auth-card input.form-control {
+  min-height: 54px;
+  border-radius: 1rem;
+  border: 1px solid rgba(27, 35, 28, 0.12);
+  background: rgba(255, 252, 247, 0.82);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.rh-auth-card input.form-control:focus {
+  border-color: rgba(31, 90, 67, 0.36);
+  box-shadow:
+    0 0 0 0.25rem rgba(31, 90, 67, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.rh-auth-divider {
+  position: relative;
+  margin: 1.6rem 0 1.15rem;
+  text-align: center;
+}
+
+.rh-auth-divider::before {
+  content: "";
+  position: absolute;
+  inset: 50% 0 auto;
+  border-top: 1px solid rgba(27, 35, 28, 0.08);
+  transform: translateY(-50%);
+}
+
+.rh-auth-divider span {
+  position: relative;
+  z-index: 1;
+  padding-inline: 0.75rem;
+  background: var(--rh-color-surface);
+  color: var(--rh-color-text-muted);
+  font-size: var(--rh-font-size-xs);
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.rh-auth-mini-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 .rh-hero {
   padding: calc(var(--rh-space-7) + 1.25rem) calc(var(--rh-space-7) + 0.5rem) calc(var(--rh-space-7) + 1rem);
   background:
@@ -1193,6 +1370,10 @@ button:focus-visible {
     grid-template-columns: 1fr;
   }
 
+  .rh-auth-frame {
+    grid-template-columns: 1fr;
+  }
+
   .rh-visual-body {
     grid-template-columns: 1fr;
   }
@@ -1215,6 +1396,11 @@ button:focus-visible {
 
   .rh-hero {
     padding: var(--rh-space-6);
+  }
+
+  .rh-auth-aside,
+  .rh-auth-card__body {
+    padding: var(--rh-space-5);
   }
 
   .rh-footer {
@@ -1283,6 +1469,10 @@ button:focus-visible {
     margin-bottom: 0.7rem;
   }
 
+  .rh-auth-aside h1 {
+    max-width: none;
+  }
+
   .rh-visual-metrics,
   .rh-workflow-grid {
     grid-template-columns: 1fr;
@@ -1310,6 +1500,11 @@ button:focus-visible {
   .rh-band--value,
   .rh-band--workflow {
     padding: 1.1rem 1rem;
+  }
+
+  .rh-auth-surface-links,
+  .rh-auth-mini-links {
+    gap: 0.6rem;
   }
 
   .rh-queue-shell__header,

--- a/templates/auth/login_base.html
+++ b/templates/auth/login_base.html
@@ -1,42 +1,62 @@
 {% extends "base.html" %}
 
+{% block title %}{{ surface_title }} | ReturnHub{% endblock %}
 {% block page_header %}{% endblock %}
 
 {% block content %}
-  <section class="rh-band rh-band--workflow py-4">
+  <section class="container py-5">
     <div class="row justify-content-center">
       <div class="col-12 col-lg-6">
-        <div class="rh-card">
-          <div class="rh-section-heading mb-4">
-            <div class="rh-kicker">{{ surface_title }}</div>
-            <h2>Sign in to {{ brand_name }}</h2>
-            <p>{{ surface_description }}</p>
-          </div>
-
-          {% if form.non_field_errors %}
-            <div class="alert alert-danger" role="alert">
-              {{ form.non_field_errors }}
+        <div class="card shadow-sm border-0 rh-card">
+          <div class="card-body p-4 p-lg-5">
+            <div class="mb-4">
+              <p class="text-uppercase text-muted small fw-semibold mb-2">{{ brand_name }}</p>
+              <h1 class="h3 mb-3">{{ surface_title }}</h1>
+              <p class="text-muted mb-0">{{ surface_description }}</p>
             </div>
-          {% endif %}
 
-          <form method="post" novalidate>
-            {% csrf_token %}
-            {% if next %}
-              <input type="hidden" name="next" value="{{ next }}">
+            {% if form.non_field_errors %}
+              <div class="alert alert-danger" role="alert">
+                {{ form.non_field_errors }}
+              </div>
             {% endif %}
 
-            <div class="mb-3">
-              <label class="form-label" for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
-              {{ form.username }}
-            </div>
+            <form method="post" novalidate>
+              {% csrf_token %}
+              {% if next %}
+                <input type="hidden" name="next" value="{{ next }}">
+              {% elif request.GET.next %}
+                <input type="hidden" name="next" value="{{ request.GET.next }}">
+              {% endif %}
 
-            <div class="mb-4">
-              <label class="form-label" for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
-              {{ form.password }}
-            </div>
+              <div class="mb-3">
+                <label class="form-label" for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
+                {{ form.username }}
+                {% if form.username.errors %}
+                  <div class="invalid-feedback d-block">{{ form.username.errors|join:", " }}</div>
+                {% endif %}
+              </div>
 
-            <button type="submit" class="btn btn-dark w-100">Sign in</button>
-          </form>
+              <div class="mb-4">
+                <label class="form-label" for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
+                {{ form.password }}
+                {% if form.password.errors %}
+                  <div class="invalid-feedback d-block">{{ form.password.errors|join:", " }}</div>
+                {% endif %}
+              </div>
+
+              <button type="submit" class="btn btn-dark btn-lg w-100">Sign in</button>
+            </form>
+
+            <hr class="my-4">
+
+            <div class="d-flex flex-wrap gap-2">
+              <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/admin/">Admin</a>
+              <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/ops/">Ops</a>
+              <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/customer/">Customer</a>
+              <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/merchant/">Merchant</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/templates/auth/login_base.html
+++ b/templates/auth/login_base.html
@@ -4,17 +4,42 @@
 {% block page_header %}{% endblock %}
 
 {% block content %}
-  <section class="container py-5">
-    <div class="row justify-content-center">
-      <div class="col-12 col-lg-6">
-        <div class="card shadow-sm border-0 rh-card">
-          <div class="card-body p-4 p-lg-5">
-            <div class="mb-4">
-              <p class="text-uppercase text-muted small fw-semibold mb-2">{{ brand_name }}</p>
-              <h1 class="h3 mb-3">{{ surface_title }}</h1>
-              <p class="text-muted mb-0">{{ surface_description }}</p>
-            </div>
+  <section class="rh-band rh-band--workflow py-4 py-lg-5">
+    <div class="rh-auth-shell">
+      <div class="rh-auth-frame">
+        <aside class="rh-auth-aside" aria-label="{{ surface_title }} guidance">
+          <div class="rh-kicker">{{ brand_name }}</div>
+          <h1>{{ surface_title }}</h1>
+          <p class="rh-auth-lead">{{ surface_description }}</p>
 
+          <div class="rh-auth-trust" aria-label="ReturnHub sign-in principles">
+            <span class="rh-trust-item">One shared auth flow</span>
+            <span class="rh-trust-item">Role-aware redirects</span>
+            <span class="rh-trust-item">Branded entry points</span>
+          </div>
+
+          <div class="rh-auth-surface-links">
+            <a class="rh-auth-surface-link {% if surface == 'admin' %}is-active{% endif %}" href="/login/admin/">Admin</a>
+            <a class="rh-auth-surface-link {% if surface == 'ops' %}is-active{% endif %}" href="/login/ops/">Ops</a>
+            <a class="rh-auth-surface-link {% if surface == 'customer' %}is-active{% endif %}" href="/login/customer/">Customer</a>
+            <a class="rh-auth-surface-link {% if surface == 'merchant' %}is-active{% endif %}" href="/login/merchant/">Merchant</a>
+          </div>
+
+          <div class="rh-auth-note">
+            <strong>Surface routing</strong>
+            <span>Successful sign-in returns the user to an allowed console or a safe requested path.</span>
+          </div>
+        </aside>
+
+        <div class="rh-auth-card rh-card">
+          <div class="rh-auth-card__topbar">
+            <span class="rh-visual-dot"></span>
+            <span class="rh-visual-dot"></span>
+            <span class="rh-visual-dot"></span>
+            <div class="rh-visual-window-title">Secure sign-in</div>
+          </div>
+
+          <div class="rh-auth-card__body">
             {% if form.non_field_errors %}
               <div class="alert alert-danger" role="alert">
                 {{ form.non_field_errors }}
@@ -45,12 +70,14 @@
                 {% endif %}
               </div>
 
-              <button type="submit" class="btn btn-dark btn-lg w-100">Sign in</button>
+              <button type="submit" class="btn btn-primary rh-btn-primary btn-lg w-100">Sign in</button>
             </form>
 
-            <hr class="my-4">
+            <div class="rh-auth-divider">
+              <span>Role entry points</span>
+            </div>
 
-            <div class="d-flex flex-wrap gap-2">
+            <div class="rh-auth-mini-links">
               <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/admin/">Admin</a>
               <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/ops/">Ops</a>
               <a class="btn btn-outline-secondary rh-btn-secondary btn-sm" href="/login/customer/">Customer</a>


### PR DESCRIPTION
## Summary

Implements and wires console pages for all ReturnHub roles while keeping the shared app shell, role-based access, and current workflow surfaces intact.

## Changes

- added and aligned role-specific console entry support for:
  - admin
  - ops
  - customer
  - merchant
- wired account-level console routes into the project
- added compatibility console view wrappers in `accounts/views_console.py`
- preserved the existing dashboard-backed console behavior by reusing the current `console.views` implementations
- introduced branded auth entry points and shared login scaffolding for all four surfaces
- added a shared auth template and surface-specific login templates
- aligned login pages with the existing ReturnHub design system so they feel native to the product shell rather than generic Bootstrap pages
- added role helper and redirect logic to support deterministic post-login routing
- added focused auth coverage tests for role helpers, redirect logic, and login view behavior

## Why

ReturnHub now needs one auth flow with four branded entry points and clear role-aware landing behavior. This PR establishes that structure while preserving the current queue, case-detail, and console experience already implemented in the project.

## Validation

- `docker compose exec web python manage.py seed_demo_data`
- `docker compose exec web python manage.py makemigrations --merge`
- `docker compose exec web python manage.py migrate --noinput`
- `docker compose exec web python -m black . --check`
- `docker compose exec web python -m ruff check .`
- `docker compose exec web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80`

## Result

- `371 passed`
- `ruff` passed
- `black --check` passed
- coverage gate passed at `98.06%`

## Notes

- this PR keeps the current dashboard templates and existing `console:` namespace behavior
- the dedicated ops workflow surfaces under `/ops/` remain the primary queue and case-detail workspace
- the auth pages now preserve the existing public `/login/.../` route contract while providing live role-specific sign-in entry points