### PR TITLE
Feat/enforce surface aware access mixins

### DIFF
--- a/accounts/mixins.py
+++ b/accounts/mixins.py
@@ -31,7 +31,7 @@ def is_admin_user(user) -> bool:
     if not getattr(user, "is_authenticated", False):
         return False
 
-    return user_in_group(user, GROUP_NAMES[ROLE_ADMIN])
+    return user.is_superuser or user_in_group(user, GROUP_NAMES[ROLE_ADMIN])
 
 
 def user_has_surface_access(user, role: str) -> bool:

--- a/accounts/mixins.py
+++ b/accounts/mixins.py
@@ -1,27 +1,41 @@
-"""Shared account-role helpers for auth and surface routing."""
+"""Surface-aware access control mixins for ReturnHub."""
 
 from __future__ import annotations
 
-from accounts.constants import GROUP_NAMES, PRIMARY_ROLE_ORDER, ROLE_ADMIN
+from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import resolve_url
+
+from accounts.constants import (
+    GROUP_NAMES,
+    ROLE_ADMIN,
+    ROLE_CUSTOMER,
+    ROLE_MERCHANT,
+    ROLE_OPS,
+    SURFACE_LOGIN_ROUTE_NAMES,
+)
 
 
 def user_in_group(user, group_name: str) -> bool:
-    """Return True when the user belongs to the supplied group name."""
+    """Return True when the user belongs to the given Django group."""
 
     if not getattr(user, "is_authenticated", False):
         return False
 
-    return user.is_superuser or user.groups.filter(name__iexact=group_name).exists()
+    return user.groups.filter(name__iexact=group_name).exists()
 
 
 def is_admin_user(user) -> bool:
-    """Return True when the user should be treated as an admin."""
+    """Return True when the user has administrative access."""
+
+    if not getattr(user, "is_authenticated", False):
+        return False
 
     return user_in_group(user, GROUP_NAMES[ROLE_ADMIN])
 
 
 def user_has_surface_access(user, role: str) -> bool:
-    """Return True when the user may access the supplied product surface."""
+    """Return True when the user may access the requested product surface."""
 
     if not getattr(user, "is_authenticated", False):
         return False
@@ -29,7 +43,58 @@ def user_has_surface_access(user, role: str) -> bool:
     if is_admin_user(user):
         return True
 
-    if role not in PRIMARY_ROLE_ORDER:
+    surface_group_lookup = {
+        ROLE_OPS: GROUP_NAMES[ROLE_OPS],
+        ROLE_CUSTOMER: GROUP_NAMES[ROLE_CUSTOMER],
+        ROLE_MERCHANT: GROUP_NAMES[ROLE_MERCHANT],
+        ROLE_ADMIN: GROUP_NAMES[ROLE_ADMIN],
+    }
+    if role not in surface_group_lookup:
         return False
 
-    return user_in_group(user, GROUP_NAMES[role])
+    return user_in_group(user, surface_group_lookup[role])
+
+
+class SurfaceAccessMixin:
+    """Redirect anonymous users to the correct surface login and 403 wrong-role users."""
+
+    required_surface: str | None = None
+
+    def dispatch(self, request, *args, **kwargs):
+        """Apply the surface login redirect or 403 contract before handling the request."""
+
+        if self.required_surface is None:
+            raise ValueError("required_surface must be set on SurfaceAccessMixin subclasses.")
+
+        if not request.user.is_authenticated:
+            login_url = resolve_url(SURFACE_LOGIN_ROUTE_NAMES[self.required_surface])
+            return redirect_to_login(request.get_full_path(), login_url)
+
+        if not user_has_surface_access(request.user, self.required_surface):
+            raise PermissionDenied("You do not have access to this ReturnHub surface.")
+
+        return super().dispatch(request, *args, **kwargs)
+
+
+class AdminSurfaceMixin(SurfaceAccessMixin):
+    """Restrict a view to the admin surface."""
+
+    required_surface = ROLE_ADMIN
+
+
+class OpsSurfaceMixin(SurfaceAccessMixin):
+    """Restrict a view to the ops surface or admin override."""
+
+    required_surface = ROLE_OPS
+
+
+class CustomerSurfaceMixin(SurfaceAccessMixin):
+    """Restrict a view to the customer surface or admin override."""
+
+    required_surface = ROLE_CUSTOMER
+
+
+class MerchantSurfaceMixin(SurfaceAccessMixin):
+    """Restrict a view to the merchant surface or admin override."""
+
+    required_surface = ROLE_MERCHANT

--- a/console/views.py
+++ b/console/views.py
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.http import JsonResponse
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.generic import TemplateView
 
+from accounts.mixins import (
+    AdminSurfaceMixin,
+    CustomerSurfaceMixin,
+    MerchantSurfaceMixin,
+    OpsSurfaceMixin,
+)
 from common.pagination import paginate_queryset
 from returns.models import ReturnCase
 from returns.ops_forms import OpsCaseUpdateForm, OpsNoteForm, OpsRequestInfoForm
@@ -69,26 +74,10 @@ MERCHANT_TIMELINE_ITEMS = (
 )
 
 
-class RoleRequiredMixin(LoginRequiredMixin, UserPassesTestMixin):
-    """Require the current user to belong to one of the configured groups."""
-
-    allowed_groups: tuple[str, ...] = ()
-    raise_exception = True
-
-    def test_func(self) -> bool:
-        """Validate group membership for the current request."""
-        user = self.request.user
-        return user.is_superuser or any(
-            user.groups.filter(name__iexact=group_name).exists()
-            for group_name in self.allowed_groups
-        )
-
-
-class AdminConsoleView(RoleRequiredMixin, TemplateView):
+class AdminConsoleView(AdminSurfaceMixin, TemplateView):
     """In-product admin console shell."""
 
     template_name = "console/admin_dashboard.html"
-    allowed_groups = ("Admin",)
 
     def get_context_data(self, **kwargs):
         """Build the admin dashboard context."""
@@ -98,10 +87,8 @@ class AdminConsoleView(RoleRequiredMixin, TemplateView):
         return context
 
 
-class BaseOpsQueueView(RoleRequiredMixin, TemplateView):
+class BaseOpsQueueView(OpsSurfaceMixin, TemplateView):
     """Shared ops queue context for the server-rendered console shell."""
-
-    allowed_groups = ("Ops", "Admin")
 
     def get_context_data(self, **kwargs):
         """Build the ops queue context."""
@@ -150,11 +137,10 @@ class OpsQueueView(OpsConsoleView):
         return context
 
 
-class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
+class OpsCaseDetailView(OpsSurfaceMixin, TemplateView):
     """Standalone ops case detail page aligned with the queue shell."""
 
     template_name = "ops/case_detail.html"
-    allowed_groups = ("Ops", "Admin")
 
     def _get_action_forms(
         self,
@@ -336,11 +322,10 @@ class OpsCaseDetailView(RoleRequiredMixin, TemplateView):
         return self.render_to_response(context, status=status_code)
 
 
-class CustomerConsoleView(RoleRequiredMixin, TemplateView):
+class CustomerConsoleView(CustomerSurfaceMixin, TemplateView):
     """Customer console shell."""
 
     template_name = "console/customer_dashboard.html"
-    allowed_groups = ("Customer", "Admin")
 
     def get_context_data(self, **kwargs):
         """Build the customer dashboard context."""
@@ -367,11 +352,10 @@ class CustomerConsoleView(RoleRequiredMixin, TemplateView):
         return context
 
 
-class MerchantConsoleView(RoleRequiredMixin, TemplateView):
+class MerchantConsoleView(MerchantSurfaceMixin, TemplateView):
     """Merchant console shell."""
 
     template_name = "console/merchant_dashboard.html"
-    allowed_groups = ("Merchant", "Admin")
 
     def get_context_data(self, **kwargs):
         """Build the merchant dashboard context."""

--- a/tests/test_accounts_auth.py
+++ b/tests/test_accounts_auth.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth.models import AnonymousUser, Group
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
 from django.test import RequestFactory
 from django.urls import reverse
+from django.views import View
 
-from accounts.mixins import is_admin_user, user_has_surface_access, user_in_group
+from accounts.mixins import (
+    OpsSurfaceMixin,
+    SurfaceAccessMixin,
+    is_admin_user,
+    user_has_surface_access,
+    user_in_group,
+)
 from accounts.services.surface_redirects import (
     get_primary_surface,
     resolve_post_login_url,
@@ -17,6 +26,29 @@ from accounts.views_auth import OpsLoginView
 from tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
+
+
+class DummySurfaceView(SurfaceAccessMixin, View):
+    """Minimal view for exercising the shared surface access dispatch logic."""
+
+    required_surface = "ops"
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("ok")
+
+
+class MissingSurfaceView(SurfaceAccessMixin, View):
+    """Minimal view with no required surface for misconfiguration tests."""
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("ok")
+
+
+class DummyOpsSurfaceView(OpsSurfaceMixin, View):
+    """Minimal ops view for subclass coverage."""
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("ok")
 
 
 def add_group(user, group_name: str) -> None:
@@ -40,6 +72,20 @@ def test_is_admin_user_returns_true_for_superuser() -> None:
     assert is_admin_user(admin_user) is True
 
 
+def test_is_admin_user_returns_false_for_authenticated_non_admin() -> None:
+    """Authenticated users without admin access should not count as admins."""
+
+    user = UserFactory()
+
+    assert is_admin_user(user) is False
+
+
+def test_is_admin_user_returns_false_for_anonymous_user() -> None:
+    """Anonymous users should never count as admins."""
+
+    assert is_admin_user(AnonymousUser()) is False
+
+
 def test_user_has_surface_access_for_matching_role() -> None:
     """Users should access only the surface that matches their role."""
 
@@ -57,6 +103,20 @@ def test_user_has_surface_access_returns_false_for_unknown_role() -> None:
     add_group(ops_user, "Ops")
 
     assert user_has_surface_access(ops_user, "unknown") is False
+
+
+def test_user_has_surface_access_returns_true_for_superuser() -> None:
+    """Superusers should be allowed onto every surface."""
+
+    admin_user = UserFactory(is_superuser=True, is_staff=True)
+
+    assert user_has_surface_access(admin_user, "ops") is True
+
+
+def test_user_has_surface_access_returns_false_for_anonymous_user() -> None:
+    """Anonymous users should never satisfy surface access checks."""
+
+    assert user_has_surface_access(AnonymousUser(), "ops") is False
 
 
 def test_get_primary_surface_prefers_first_matching_role() -> None:
@@ -148,3 +208,65 @@ def test_ops_login_view_context_exposes_surface_content() -> None:
     assert context["surface"] == "ops"
     assert context["surface_title"] == "Ops surface"
     assert context["surface_description"] == "Ops entry is reserved for queue-driven work."
+
+
+def test_surface_access_mixin_redirects_anonymous_users_to_surface_login() -> None:
+    """Anonymous requests should be redirected to the configured surface login."""
+
+    request = RequestFactory().get("/console/ops/")
+    request.user = AnonymousUser()
+
+    response = DummySurfaceView.as_view()(request)
+
+    assert response.status_code == 302
+    assert response.url == f"{reverse('accounts:login_ops')}?next=/console/ops/"
+
+
+def test_surface_access_mixin_raises_for_missing_required_surface() -> None:
+    """Surface views must declare a required surface."""
+
+    request = RequestFactory().get("/console/ops/")
+    request.user = AnonymousUser()
+
+    with pytest.raises(ValueError, match="required_surface must be set"):
+        MissingSurfaceView.as_view()(request)
+
+
+def test_surface_access_mixin_raises_permission_denied_for_wrong_role() -> None:
+    """Authenticated users without surface access should receive a 403 contract."""
+
+    customer_user = UserFactory()
+    add_group(customer_user, "Customer")
+    request = RequestFactory().get("/console/ops/")
+    request.user = customer_user
+
+    with pytest.raises(PermissionDenied, match="do not have access"):
+        DummySurfaceView.as_view()(request)
+
+
+def test_surface_access_mixin_allows_authorized_user_through_dispatch() -> None:
+    """Authorized users should reach the wrapped view."""
+
+    ops_user = UserFactory()
+    add_group(ops_user, "Ops")
+    request = RequestFactory().get("/console/ops/")
+    request.user = ops_user
+
+    response = DummySurfaceView.as_view()(request)
+
+    assert response.status_code == 200
+    assert response.content == b"ok"
+
+
+def test_ops_surface_mixin_inherits_ops_surface_contract() -> None:
+    """Concrete surface mixins should enforce the same access behavior."""
+
+    ops_user = UserFactory()
+    add_group(ops_user, "Ops")
+    request = RequestFactory().get("/console/ops/")
+    request.user = ops_user
+
+    response = DummyOpsSurfaceView.as_view()(request)
+
+    assert response.status_code == 200
+    assert response.content == b"ok"


### PR DESCRIPTION
## Summary

Introduces surface-aware access mixins for ReturnHub and applies the centralized access contract across existing surface views.

## Changes

- added surface-aware access helpers in `accounts/mixins.py`
- introduced:
  - `SurfaceAccessMixin`
  - `AdminSurfaceMixin`
  - `OpsSurfaceMixin`
  - `CustomerSurfaceMixin`
  - `MerchantSurfaceMixin`
- centralized anonymous-user redirect behavior to the correct surface login page
- centralized authenticated wrong-role behavior to a `403`
- updated existing console and workflow views in `console/views.py` to use the new surface mixins
- preserved admin override behavior for superusers
- kept role checks aligned with the project’s current group naming conventions
- retained the existing console/dashboard/workflow page logic while moving access control into shared mixins

## Why

The project needed one consistent access-control layer for surface views so future role-specific views can stay thin and avoid repeating redirect and permission logic. This change consolidates that behavior into reusable mixins and applies it across the current console/workflow surfaces.

## Validation

- `docker compose exec web python manage.py seed_demo_data`
- `docker compose exec web python manage.py makemigrations --merge`
- `docker compose exec web python manage.py migrate --noinput`
- `docker compose exec web python -m black . --check`
- `docker compose exec web python -m ruff check .`
- `docker compose exec web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80`

## Result

- tests passed after restoring superuser override behavior
- lint and formatting checks passed
- coverage gate remained well above threshold

## Notes

- this PR changes access-control wiring, not the underlying page content
- existing dashboards and workflow templates remain intact
- superusers continue to bypass role-group requirements, matching prior project behavior