### PR TITLE
Feat/test login routing and console access

### DIFF
--- a/tests/test_console_access.py
+++ b/tests/test_console_access.py
@@ -1,0 +1,66 @@
+# path: tests/test_console_access.py
+"""Integration tests for surface console access behaviour."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from apps.accounts.constants import GROUP_NAMES, ROLE_CUSTOMER, ROLE_OPS
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+def create_user_for_role(username, role, password="pass-12345"):
+    """Create a user assigned to the requested role group."""
+    group, _ = Group.objects.get_or_create(name=GROUP_NAMES[role])
+    user = User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password=password,
+    )
+    user.groups.add(group)
+    return user
+
+
+def test_anonymous_customer_console_redirects_to_customer_login(client):
+    """Anonymous users should be sent to the customer login page with next preserved."""
+    response = client.get(reverse("accounts:console_customer"))
+
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith(reverse("accounts:login_customer"))
+    assert "next=%2Fconsole%2Fcustomer%2F" in response.headers["Location"]
+
+
+def test_customer_can_access_customer_console(client):
+    """Customers may open their own console."""
+    user = create_user_for_role("customer.one", ROLE_CUSTOMER)
+    client.force_login(user)
+
+    response = client.get(reverse("accounts:console_customer"))
+
+    assert response.status_code == 200
+    assert b"Track your return cases" in response.content
+
+
+def test_customer_gets_403_on_ops_console(client):
+    """Authenticated wrong-role users should receive a clean 403 response."""
+    user = create_user_for_role("customer.two", ROLE_CUSTOMER)
+    client.force_login(user)
+
+    response = client.get(reverse("accounts:console_ops"))
+
+    assert response.status_code == 403
+
+
+def test_ops_can_access_ops_console(client):
+    """Ops users may open their own console."""
+    user = create_user_for_role("ops.one", ROLE_OPS)
+    client.force_login(user)
+
+    response = client.get(reverse("accounts:console_ops"))
+
+    assert response.status_code == 200
+    assert b"Triage and case workflow" in response.content

--- a/tests/test_console_access.py
+++ b/tests/test_console_access.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from apps.accounts.constants import GROUP_NAMES, ROLE_CUSTOMER, ROLE_OPS
+from accounts.constants import GROUP_NAMES, ROLE_CUSTOMER, ROLE_OPS
 
 pytestmark = pytest.mark.django_db
 
@@ -31,7 +31,7 @@ def test_anonymous_customer_console_redirects_to_customer_login(client):
 
     assert response.status_code == 302
     assert response.headers["Location"].startswith(reverse("accounts:login_customer"))
-    assert "next=%2Fconsole%2Fcustomer%2F" in response.headers["Location"]
+    assert "next=/console/customer/" in response.headers["Location"]
 
 
 def test_customer_can_access_customer_console(client):
@@ -42,7 +42,7 @@ def test_customer_can_access_customer_console(client):
     response = client.get(reverse("accounts:console_customer"))
 
     assert response.status_code == 200
-    assert b"Track your return cases" in response.content
+    assert b"Track the most recent return activity in one customer-facing shell." in response.content
 
 
 def test_customer_gets_403_on_ops_console(client):
@@ -63,4 +63,4 @@ def test_ops_can_access_ops_console(client):
     response = client.get(reverse("accounts:console_ops"))
 
     assert response.status_code == 200
-    assert b"Triage and case workflow" in response.content
+    assert b"Work the live return queue inside the same shared ReturnHub shell." in response.content

--- a/tests/test_console_access.py
+++ b/tests/test_console_access.py
@@ -42,7 +42,9 @@ def test_customer_can_access_customer_console(client):
     response = client.get(reverse("accounts:console_customer"))
 
     assert response.status_code == 200
-    assert b"Track the most recent return activity in one customer-facing shell." in response.content
+    assert (
+        b"Track the most recent return activity in one customer-facing shell." in response.content
+    )
 
 
 def test_customer_gets_403_on_ops_console(client):

--- a/tests/test_surface_login_views.py
+++ b/tests/test_surface_login_views.py
@@ -1,0 +1,65 @@
+# path: tests/test_surface_login_views.py
+"""Integration tests for surface login routing."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from apps.accounts.constants import GROUP_NAMES, ROLE_CUSTOMER, ROLE_OPS
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+def create_user_for_role(username, role, password="pass-12345"):
+    """Create a user assigned to the requested role group."""
+    group, _ = Group.objects.get_or_create(name=GROUP_NAMES[role])
+    user = User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password=password,
+    )
+    user.groups.add(group)
+    return user
+
+
+def test_customer_login_redirects_to_customer_console(client):
+    """Customer login should land on the customer console."""
+    user = create_user_for_role("customer.one", ROLE_CUSTOMER)
+
+    response = client.post(
+        reverse("accounts:login_customer"),
+        {"username": user.username, "password": "pass-12345"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == reverse("accounts:console_customer")
+
+
+def test_wrong_surface_login_redirects_to_primary_surface(client):
+    """An ops user using the customer login page should be routed to the ops console."""
+    user = create_user_for_role("ops.one", ROLE_OPS)
+
+    response = client.post(
+        reverse("accounts:login_customer"),
+        {"username": user.username, "password": "pass-12345"},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == reverse("accounts:console_ops")
+
+
+def test_surface_login_preserves_allowed_next_path(client):
+    """A surface login should honour an allowed next path for the same user role."""
+    user = create_user_for_role("customer.two", ROLE_CUSTOMER)
+    target_path = "/console/customer/"
+
+    response = client.post(
+        f"{reverse('accounts:login_customer')}?next={target_path}",
+        {"username": user.username, "password": "pass-12345", "next": target_path},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == target_path

--- a/tests/test_surface_login_views.py
+++ b/tests/test_surface_login_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from apps.accounts.constants import GROUP_NAMES, ROLE_CUSTOMER, ROLE_OPS
+from accounts.constants import GROUP_NAMES, ROLE_CUSTOMER, ROLE_OPS
 
 pytestmark = pytest.mark.django_db
 


### PR DESCRIPTION
## Summary

Adds focused test coverage for surface-specific login routing and role-aware console access across the ReturnHub auth and console flows.

## Changes

- added login routing tests in `tests/test_surface_login_views.py`
- added console access tests in `tests/test_console_access.py`
- verified role-based login outcomes for customer and ops users
- verified deterministic post-login redirects to the correct console surface
- verified allowed `next` path preservation on surface login
- verified anonymous console access redirects to the correct surface login page
- verified authenticated wrong-role users receive a `403`
- aligned the new test files with the current project module layout and dashboard copy
- updated stale assertions to match the current console templates and redirect header behavior

## Why

The project now relies on branded surface login routes and centralized surface-aware access control. These tests ensure that login routing and console access stay stable as the auth and surface-mixin work evolves.

## Validation

- `docker compose exec web python manage.py seed_demo_data`
- `docker compose exec web python manage.py makemigrations --merge`
- `docker compose exec web python manage.py migrate --noinput`
- `docker compose exec web python -m black . --check`
- `docker compose exec web python -m ruff check .`
- `docker compose exec web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80`

## Result

- `387 passed`
- coverage gate passed at `98.25%`
- migrations remained clean
- the only follow-up needed after the latest run was formatting `tests/test_console_access.py`

## Notes

- this PR focuses on verification coverage, not application logic changes
- the new tests are aligned with the current top-level `accounts.*` module layout
- assertions were matched to the current ReturnHub dashboard copy and redirect behavior