### PR TITLE
Feat/test customer portal pagination and ownership

### DIFF
--- a/tests/test_customer_portal_views.py
+++ b/tests/test_customer_portal_views.py
@@ -23,11 +23,17 @@ def test_customer_portal_routes_resolve_to_live_views() -> None:
 
     assert reverse("customer_portal:case_list") == "/customer/"
     assert resolve("/customer/").view_name == "customer_portal:case_list"
-    assert reverse("customer_portal:case_detail", kwargs={"case_id": 42}) == "/customer/42/"
+    assert reverse(
+        "customer_portal:case_detail",
+        kwargs={"case_id": 42},
+    ) == "/customer/42/"
     assert resolve("/customer/42/").view_name == "customer_portal:case_detail"
 
 
-def test_customer_case_list_paginates_and_hides_other_customers(client, db) -> None:
+def test_customer_case_list_paginates_and_hides_other_customers(
+    client,
+    db,
+) -> None:
     """Customers should see only their own cases across page 1 and page 2."""
 
     first_case = ReturnCaseFactory(order_reference="CUST-LIST-001")
@@ -55,7 +61,10 @@ def test_customer_case_list_paginates_and_hides_other_customers(client, db) -> N
     assert b"CUST-OTHER-001" not in response_page_2.content
 
 
-def test_customer_case_list_invalid_and_out_of_range_pages_fall_back_cleanly(client, db) -> None:
+def test_customer_case_list_invalid_and_out_of_range_pages_fall_back_cleanly(
+    client,
+    db,
+) -> None:
     """Invalid pages should resolve to page 1 and out-of-range values to the last page."""
 
     first_case = ReturnCaseFactory(order_reference="CUST-PAGE-001")
@@ -108,7 +117,13 @@ def test_customer_case_detail_post_redirects_after_successful_upload(
 
     captured = {}
 
-    def fake_upload_customer_evidence(*, return_case, uploaded_by, uploaded_file, description):
+    def fake_upload_customer_evidence(
+        *,
+        return_case,
+        uploaded_by,
+        uploaded_file,
+        description,
+    ):
         captured["case"] = return_case
         captured["uploaded_by"] = uploaded_by
         captured["filename"] = uploaded_file.name

--- a/tests/test_customer_portal_views.py
+++ b/tests/test_customer_portal_views.py
@@ -23,10 +23,13 @@ def test_customer_portal_routes_resolve_to_live_views() -> None:
 
     assert reverse("customer_portal:case_list") == "/customer/"
     assert resolve("/customer/").view_name == "customer_portal:case_list"
-    assert reverse(
-        "customer_portal:case_detail",
-        kwargs={"case_id": 42},
-    ) == "/customer/42/"
+    assert (
+        reverse(
+            "customer_portal:case_detail",
+            kwargs={"case_id": 42},
+        )
+        == "/customer/42/"
+    )
     assert resolve("/customer/42/").view_name == "customer_portal:case_detail"
 
 
@@ -185,14 +188,20 @@ def test_customer_can_upload_evidence_to_owned_case(client, db, monkeypatch) -> 
     )
 
     assert response.status_code == 302
-    assert EvidenceDocument.objects.filter(
-        return_case=return_case,
-        kind=EvidenceDocument.DocumentKind.EVIDENCE,
-    ).count() == 1
-    assert CaseEvent.objects.filter(
-        return_case=return_case,
-        event_type="document_uploaded",
-    ).count() == 1
+    assert (
+        EvidenceDocument.objects.filter(
+            return_case=return_case,
+            kind=EvidenceDocument.DocumentKind.EVIDENCE,
+        ).count()
+        == 1
+    )
+    assert (
+        CaseEvent.objects.filter(
+            return_case=return_case,
+            event_type="document_uploaded",
+        ).count()
+        == 1
+    )
 
 
 def test_customer_case_detail_post_renders_errors_for_invalid_upload(client, db) -> None:
@@ -221,9 +230,7 @@ def test_customer_cannot_open_another_customers_case(client, db) -> None:
     add_group(other_case.customer.user, "customer")
 
     client.force_login(own_case.customer.user)
-    response = client.get(
-        reverse("customer_portal:case_detail", kwargs={"case_id": other_case.pk})
-    )
+    response = client.get(reverse("customer_portal:case_detail", kwargs={"case_id": other_case.pk}))
 
     assert own_case.customer.pk != other_case.customer.pk
     assert response.status_code == 404

--- a/tests/test_customer_portal_views.py
+++ b/tests/test_customer_portal_views.py
@@ -7,6 +7,7 @@ from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import resolve, reverse
 
+from returns.models import CaseEvent, EvidenceDocument
 from tests.factories import ReturnCaseFactory
 
 
@@ -26,18 +27,56 @@ def test_customer_portal_routes_resolve_to_live_views() -> None:
     assert resolve("/customer/42/").view_name == "customer_portal:case_detail"
 
 
-def test_customer_case_list_view_renders_for_linked_customer(client, db) -> None:
-    """The customer portal list should render the current customer's cases."""
+def test_customer_case_list_paginates_and_hides_other_customers(client, db) -> None:
+    """Customers should see only their own cases across page 1 and page 2."""
 
-    return_case = ReturnCaseFactory(order_reference="CUST-LIST-001")
-    add_group(return_case.customer.user, "customer")
+    first_case = ReturnCaseFactory(order_reference="CUST-LIST-001")
+    customer_user = first_case.customer.user
+    add_group(customer_user, "customer")
+    other_case = ReturnCaseFactory(order_reference="CUST-OTHER-001")
+    add_group(other_case.customer.user, "customer")
 
-    client.force_login(return_case.customer.user)
-    response = client.get(reverse("customer_portal:case_list"))
+    for index in range(16):
+        ReturnCaseFactory(
+            customer=first_case.customer,
+            merchant=first_case.merchant,
+            order_reference=f"CUST-LIST-{index + 2:03d}",
+        )
 
-    assert response.status_code == 200
-    assert b"Customer Portal" in response.content
-    assert b"CUST-LIST-001" in response.content
+    client.force_login(customer_user)
+    response_page_1 = client.get(reverse("customer_portal:case_list"))
+    response_page_2 = client.get(f"{reverse('customer_portal:case_list')}?page=2")
+
+    assert response_page_1.status_code == 200
+    assert response_page_2.status_code == 200
+    assert b"Showing 1-15 of 17" in response_page_1.content
+    assert b"Showing 16-17 of 17" in response_page_2.content
+    assert b"CUST-OTHER-001" not in response_page_1.content
+    assert b"CUST-OTHER-001" not in response_page_2.content
+
+
+def test_customer_case_list_invalid_and_out_of_range_pages_fall_back_cleanly(client, db) -> None:
+    """Invalid pages should resolve to page 1 and out-of-range values to the last page."""
+
+    first_case = ReturnCaseFactory(order_reference="CUST-PAGE-001")
+    customer_user = first_case.customer.user
+    add_group(customer_user, "customer")
+
+    for index in range(15):
+        ReturnCaseFactory(
+            customer=first_case.customer,
+            merchant=first_case.merchant,
+            order_reference=f"CUST-PAGE-{index + 2:03d}",
+        )
+
+    client.force_login(customer_user)
+    invalid_response = client.get(f"{reverse('customer_portal:case_list')}?page=banana")
+    last_page_response = client.get(f"{reverse('customer_portal:case_list')}?page=999")
+
+    assert invalid_response.status_code == 200
+    assert last_page_response.status_code == 200
+    assert b"Showing 1-15 of 16" in invalid_response.content
+    assert b"Showing 16-16 of 16" in last_page_response.content
 
 
 def test_customer_case_detail_view_renders_for_linked_customer(client, db) -> None:
@@ -106,6 +145,41 @@ def test_customer_case_detail_post_redirects_after_successful_upload(
     assert "Document uploaded successfully." in messages
 
 
+def test_customer_can_upload_evidence_to_owned_case(client, db, monkeypatch) -> None:
+    """Posting an evidence file should create a document and a case event."""
+
+    return_case = ReturnCaseFactory(order_reference="CUST-UPLOAD-REAL-001")
+    add_group(return_case.customer.user, "customer")
+    monkeypatch.setattr(
+        "returns.services.documents.score_case_and_persist",
+        lambda *args, **kwargs: None,
+    )
+
+    client.force_login(return_case.customer.user)
+    response = client.post(
+        reverse("customer_portal:case_detail", kwargs={"case_id": return_case.pk}),
+        data={
+            "kind": EvidenceDocument.DocumentKind.EVIDENCE,
+            "notes": "Photo of damaged packaging.",
+            "file": SimpleUploadedFile(
+                "photo.jpg",
+                b"binary-image-content",
+                content_type="image/jpeg",
+            ),
+        },
+    )
+
+    assert response.status_code == 302
+    assert EvidenceDocument.objects.filter(
+        return_case=return_case,
+        kind=EvidenceDocument.DocumentKind.EVIDENCE,
+    ).count() == 1
+    assert CaseEvent.objects.filter(
+        return_case=return_case,
+        event_type="document_uploaded",
+    ).count() == 1
+
+
 def test_customer_case_detail_post_renders_errors_for_invalid_upload(client, db) -> None:
     """Invalid customer uploads should re-render the page with a 400 status."""
 
@@ -121,3 +195,20 @@ def test_customer_case_detail_post_renders_errors_for_invalid_upload(client, db)
     assert response.status_code == 400
     assert b"Document actions" in response.content
     assert b"This field is required." in response.content
+
+
+def test_customer_cannot_open_another_customers_case(client, db) -> None:
+    """A customer should receive 404 when trying to open another customer's case."""
+
+    own_case = ReturnCaseFactory(order_reference="CUST-OWN-001")
+    other_case = ReturnCaseFactory(order_reference="CUST-OTHER-DETAIL-001")
+    add_group(own_case.customer.user, "customer")
+    add_group(other_case.customer.user, "customer")
+
+    client.force_login(own_case.customer.user)
+    response = client.get(
+        reverse("customer_portal:case_detail", kwargs={"case_id": other_case.pk})
+    )
+
+    assert own_case.customer.pk != other_case.customer.pk
+    assert response.status_code == 404


### PR DESCRIPTION
**Summary**
Adds customer portal test coverage for pagination behaviour, ownership scoping, and customer evidence upload flows.

**Changes**
- expanded customer portal view tests to cover route resolution for list and detail pages
- added pagination coverage for page 1, page 2, invalid page values, and out-of-range page values
- added coverage to ensure customers only see their own cases in the portal list
- added detail-view coverage for authorized customer access
- added ownership-scoping coverage to ensure one customer cannot open another customer’s case
- added upload coverage for both successful redirect behaviour and real document/event persistence
- aligned landing-page scaffold tests with the current ReturnHub landing copy
- formatted the updated customer portal test file to satisfy project style checks

**Why**
The customer portal introduced new list and detail routes with customer-specific visibility rules. These tests ensure pagination remains stable, customer ownership boundaries are enforced, and evidence uploads follow the expected transactional document/event path.

**Validation**
- `docker compose exec web python manage.py seed_demo_data`
- `docker compose exec web python manage.py makemigrations --merge`
- `docker compose exec web python manage.py migrate --noinput`
- `docker compose exec web python -m black . --check`
- `docker compose exec web python -m ruff check .`
- `docker compose exec web pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=80`

**Result**
- full suite passed: `399 passed`
- lint passed
- coverage threshold passed: `98.26%`
- customer portal pagination, ownership, and upload paths are now covered by targeted tests

**Notes**
- the merged test coverage was adapted to this repo’s actual implementation, not the stale `apps.*` structure
- the live contract is `case_id` routes, shared upload form fields, `EvidenceDocument.DocumentKind.EVIDENCE`, and `CaseEvent.event_type == "document_uploaded"`