### PR TITLE
Feat/add merchant response submission flow

### DIFF
--- a/returns/forms_merchant.py
+++ b/returns/forms_merchant.py
@@ -1,0 +1,32 @@
+# path: returns/forms_merchant.py
+"""Merchant-facing forms for response submission."""
+
+from django import forms
+
+
+class MerchantResponseForm(forms.Form):
+    """Allow a merchant to submit a response note and optional document."""
+
+    response_note = forms.CharField(
+        label="Response note",
+        required=False,
+        widget=forms.Textarea(
+            attrs={
+                "class": "form-control",
+                "rows": 5,
+                "placeholder": "Add context for the ops team or explain the merchant position.",
+            }
+        ),
+    )
+    response_file = forms.FileField(
+        label="Supporting file",
+        required=False,
+        widget=forms.ClearableFileInput(attrs={"class": "form-control"}),
+    )
+
+    def clean(self):
+        """Require at least one response input."""
+        cleaned_data = super().clean()
+        if not cleaned_data.get("response_note") and not cleaned_data.get("response_file"):
+            raise forms.ValidationError("Add a response note, a supporting file, or both.")
+        return cleaned_data

--- a/returns/forms_merchant.py
+++ b/returns/forms_merchant.py
@@ -1,5 +1,6 @@
-# path: returns/forms_merchant.py
 """Merchant-facing forms for response submission."""
+
+from __future__ import annotations
 
 from django import forms
 
@@ -24,8 +25,14 @@ class MerchantResponseForm(forms.Form):
         widget=forms.ClearableFileInput(attrs={"class": "form-control"}),
     )
 
+    def clean_response_note(self) -> str:
+        """Normalize surrounding whitespace on the merchant note."""
+
+        return (self.cleaned_data.get("response_note") or "").strip()
+
     def clean(self):
         """Require at least one response input."""
+
         cleaned_data = super().clean()
         if not cleaned_data.get("response_note") and not cleaned_data.get("response_file"):
             raise forms.ValidationError("Add a response note, a supporting file, or both.")

--- a/returns/services/merchant_portal.py
+++ b/returns/services/merchant_portal.py
@@ -83,6 +83,29 @@ def get_merchant_case_for_user(user, case_pk: int) -> ReturnCase:
     return get_object_or_404(queryset, pk=case_pk)
 
 
+def build_merchant_case_detail_context(user, case_pk: int) -> dict[str, object]:
+    """Return merchant case detail context with dashboard-specific signals."""
+
+    return_case = get_merchant_case_for_user(user, case_pk)
+    response_history = [
+        event
+        for event in return_case.events.all()
+        if event.event_type == "merchant_response_submitted"
+    ]
+    merchant_activity = [
+        event
+        for event in return_case.events.all()
+        if event.actor_role == "merchant" or event.event_type == "merchant_response_submitted"
+    ]
+
+    return {
+        "case": return_case,
+        "latest_merchant_response": response_history[0] if response_history else None,
+        "merchant_response_history": response_history,
+        "merchant_activity": merchant_activity,
+    }
+
+
 @transaction.atomic
 def submit_merchant_response(
     return_case,

--- a/returns/services/merchant_portal.py
+++ b/returns/services/merchant_portal.py
@@ -12,6 +12,7 @@ from django.shortcuts import get_object_or_404
 from accounts.mixins import is_admin_user
 from common.pagination import paginate_queryset
 from returns.models import CaseEvent, EvidenceDocument, ReturnCase
+from returns.services.cases import _actor_role
 from returns.services.documents import DocumentUploadInput, upload_document_for_case
 
 
@@ -83,15 +84,39 @@ def get_merchant_case_for_user(user, case_pk: int) -> ReturnCase:
 
 
 @transaction.atomic
-def upload_merchant_response(return_case, uploaded_by, uploaded_file, description: str = ""):
-    """Persist merchant response documents using the canonical upload service."""
+def submit_merchant_response(
+    return_case,
+    submitted_by,
+    response_note: str = "",
+    response_file=None,
+):
+    """Persist a merchant response event and optional supporting document."""
 
-    return upload_document_for_case(
+    response_note = (response_note or "").strip()
+    document = None
+
+    if response_file is not None:
+        document = upload_document_for_case(
+            return_case=return_case,
+            actor=submitted_by,
+            upload_input=DocumentUploadInput(
+                kind=EvidenceDocument.DocumentKind.RESPONSE,
+                uploaded_file=response_file,
+                notes=response_note,
+            ),
+        )
+
+    CaseEvent.objects.create(
         return_case=return_case,
-        actor=uploaded_by,
-        upload_input=DocumentUploadInput(
-            kind=EvidenceDocument.DocumentKind.RESPONSE,
-            uploaded_file=uploaded_file,
-            notes=description,
-        ),
+        actor=submitted_by,
+        actor_role=_actor_role(submitted_by),
+        event_type="merchant_response_submitted",
+        payload={
+            "response_note": response_note,
+            "document_id": str(document.pk) if document else "",
+            "document_kind": document.kind if document else "",
+            "has_document": document is not None,
+        },
     )
+
+    return document

--- a/returns/views_merchant.py
+++ b/returns/views_merchant.py
@@ -10,8 +10,8 @@ from django.views.generic import TemplateView
 from accounts.mixins import MerchantSurfaceMixin
 from returns.forms_merchant import MerchantResponseForm
 from returns.services.merchant_portal import (
+    build_merchant_case_detail_context,
     build_merchant_case_page,
-    get_merchant_case_for_user,
     submit_merchant_response,
 )
 
@@ -37,16 +37,23 @@ class MerchantCaseDetailView(MerchantSurfaceMixin, View):
     def get_case(self):
         """Return the merchant-visible case for the current request."""
 
-        return get_merchant_case_for_user(self.request.user, self.kwargs["case_id"])
+        return build_merchant_case_detail_context(
+            self.request.user,
+            self.kwargs["case_id"],
+        )["case"]
 
     def get(self, request, *args, **kwargs):
         """Render the case detail page."""
 
+        context = build_merchant_case_detail_context(
+            self.request.user,
+            self.kwargs["case_id"],
+        )
         return render(
             request,
             self.template_name,
             {
-                "case": self.get_case(),
+                **context,
                 "form": MerchantResponseForm(),
             },
         )
@@ -74,7 +81,10 @@ class MerchantCaseDetailView(MerchantSurfaceMixin, View):
             request,
             self.template_name,
             {
-                "case": case,
+                **build_merchant_case_detail_context(
+                    self.request.user,
+                    self.kwargs["case_id"],
+                ),
                 "form": form,
             },
         )

--- a/returns/views_merchant.py
+++ b/returns/views_merchant.py
@@ -8,12 +8,12 @@ from django.views import View
 from django.views.generic import TemplateView
 
 from accounts.mixins import MerchantSurfaceMixin
+from returns.forms_merchant import MerchantResponseForm
 from returns.services.merchant_portal import (
     build_merchant_case_page,
     get_merchant_case_for_user,
-    upload_merchant_response,
+    submit_merchant_response,
 )
-from ui.forms import CaseDocumentUploadForm
 
 
 class MerchantCaseListView(MerchantSurfaceMixin, TemplateView):
@@ -47,7 +47,7 @@ class MerchantCaseDetailView(MerchantSurfaceMixin, View):
             self.template_name,
             {
                 "case": self.get_case(),
-                "form": CaseDocumentUploadForm(actor_role="merchant"),
+                "form": MerchantResponseForm(),
             },
         )
 
@@ -55,20 +55,19 @@ class MerchantCaseDetailView(MerchantSurfaceMixin, View):
         """Handle merchant response uploads on the case detail page."""
 
         case = self.get_case()
-        form = CaseDocumentUploadForm(
+        form = MerchantResponseForm(
             request.POST,
             request.FILES,
-            actor_role="merchant",
         )
 
         if form.is_valid():
-            upload_merchant_response(
+            submit_merchant_response(
                 return_case=case,
-                uploaded_by=request.user,
-                uploaded_file=form.cleaned_data["file"],
-                description=form.cleaned_data["notes"],
+                submitted_by=request.user,
+                response_note=form.cleaned_data["response_note"],
+                response_file=form.cleaned_data["response_file"],
             )
-            messages.success(request, "Response uploaded successfully.")
+            messages.success(request, "Response submitted successfully.")
             return redirect("merchant_portal:case_detail", case_id=case.pk)
 
         response = render(

--- a/templates/merchant/case_detail.html
+++ b/templates/merchant/case_detail.html
@@ -50,6 +50,75 @@
     <div class="col-12 col-xl-8">
       <section class="rh-card mb-4">
         <div class="rh-section-heading mb-3">
+          <div class="rh-kicker">Merchant Dashboard</div>
+          <h2>Track the latest merchant response and the running response trail.</h2>
+        </div>
+        <div class="row g-3">
+          <div class="col-12 col-lg-6">
+            <div class="rh-visual-panel rh-visual-panel--case h-100">
+              <h3 class="h5">Latest merchant response</h3>
+              {% if latest_merchant_response %}
+                <p class="text-muted small mb-2">
+                  {{ latest_merchant_response.created_at|date:"j M Y, H:i" }}
+                </p>
+                <p class="mb-2">
+                  {{ latest_merchant_response.payload.response_note|default:"No note provided." }}
+                </p>
+                <div class="rh-visual-meta">
+                  <span>
+                    {% if latest_merchant_response.payload.has_document %}
+                      Includes supporting file
+                    {% else %}
+                      Note only
+                    {% endif %}
+                  </span>
+                  {% if latest_merchant_response.payload.document_kind %}
+                    <span>{{ latest_merchant_response.payload.document_kind|title }}</span>
+                  {% endif %}
+                </div>
+              {% else %}
+                <p class="mb-0 text-muted">
+                  No merchant response has been submitted yet.
+                </p>
+              {% endif %}
+            </div>
+          </div>
+          <div class="col-12 col-lg-6">
+            <div class="rh-visual-panel rh-visual-panel--case h-100">
+              <h3 class="h5">Response history</h3>
+              {% if merchant_response_history %}
+                <ol class="list-unstyled mb-0">
+                  {% for event in merchant_response_history %}
+                    <li class="{% if not forloop.last %}pb-3 mb-3 border-bottom{% endif %}">
+                      <div class="d-flex justify-content-between gap-3">
+                        <strong>Response {{ forloop.revcounter }}</strong>
+                        <span class="text-muted small">{{ event.created_at|date:"j M Y, H:i" }}</span>
+                      </div>
+                      <p class="mb-1">
+                        {{ event.payload.response_note|default:"No note provided." }}
+                      </p>
+                      <div class="text-muted small">
+                        {% if event.payload.has_document %}
+                          Supporting file attached
+                        {% else %}
+                          Note only
+                        {% endif %}
+                      </div>
+                    </li>
+                  {% endfor %}
+                </ol>
+              {% else %}
+                <p class="mb-0 text-muted">
+                  Merchant responses will appear here in append-only order once submitted.
+                </p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rh-card mb-4">
+        <div class="rh-section-heading mb-3">
           <div class="rh-kicker">Documents</div>
           <h2>Merchant-visible evidence and response files linked to this return.</h2>
         </div>
@@ -58,10 +127,10 @@
 
       <section class="rh-card">
         <div class="rh-section-heading mb-3">
-          <div class="rh-kicker">Timeline</div>
-          <h2>Append-only case history for the current return.</h2>
+          <div class="rh-kicker">Merchant Activity</div>
+          <h2>Merchant-side actions and response events for the current return.</h2>
         </div>
-        {% include "partials/_timeline.html" with events=case.events.all %}
+        {% include "partials/_timeline.html" with events=merchant_activity %}
       </section>
     </div>
 

--- a/templates/merchant/case_detail.html
+++ b/templates/merchant/case_detail.html
@@ -69,23 +69,10 @@
       <section class="rh-card" aria-label="Merchant response upload panel">
         <div class="rh-kicker">Uploads</div>
         <h2 class="h4">Merchant response</h2>
-        {% include "partials/_form_errors.html" with form=form %}
-        <form method="post" enctype="multipart/form-data">
-          {% csrf_token %}
-          <div class="mb-3">
-            <label class="form-label" for="{{ form.kind.id_for_label }}">Document kind</label>
-            {{ form.kind }}
-          </div>
-          <div class="mb-3">
-            <label class="form-label" for="{{ form.file.id_for_label }}">File</label>
-            {{ form.file }}
-          </div>
-          <div class="mb-3">
-            <label class="form-label" for="{{ form.notes.id_for_label }}">Notes</label>
-            {{ form.notes }}
-          </div>
-          <button type="submit" class="btn btn-dark">Upload response</button>
-        </form>
+        <p class="text-muted mb-3">
+          Submit a note-only response or attach a supporting file when the case needs merchant-side context.
+        </p>
+        {% include "merchant/partials/_response_form.html" with form=form %}
       </section>
     </div>
   </div>

--- a/templates/merchant/partials/_response_form.html
+++ b/templates/merchant/partials/_response_form.html
@@ -1,28 +1,27 @@
-<!--path: templates/merchant/partials/_response_form.html-->
 <form method="post" enctype="multipart/form-data" novalidate>
-    {% csrf_token %}
+  {% csrf_token %}
 
-    {% if form.non_field_errors %}
-        <div class="alert alert-danger" role="alert">
-            {{ form.non_field_errors }}
-        </div>
+  {% include "partials/_form_errors.html" with form=form %}
+
+  <div class="mb-3">
+    <label class="form-label" for="{{ form.response_note.id_for_label }}">
+      {{ form.response_note.label }}
+    </label>
+    {{ form.response_note }}
+    {% if form.response_note.errors %}
+      <div class="invalid-feedback d-block">{{ form.response_note.errors|join:", " }}</div>
     {% endif %}
+  </div>
 
-    <div class="mb-3">
-        <label class="form-label" for="{{ form.response_note.id_for_label }}">{{ form.response_note.label }}</label>
-        {{ form.response_note }}
-        {% if form.response_note.errors %}
-            <div class="invalid-feedback d-block">{{ form.response_note.errors|join:", " }}</div>
-        {% endif %}
-    </div>
+  <div class="mb-3">
+    <label class="form-label" for="{{ form.response_file.id_for_label }}">
+      {{ form.response_file.label }}
+    </label>
+    {{ form.response_file }}
+    {% if form.response_file.errors %}
+      <div class="invalid-feedback d-block">{{ form.response_file.errors|join:", " }}</div>
+    {% endif %}
+  </div>
 
-    <div class="mb-3">
-        <label class="form-label" for="{{ form.response_file.id_for_label }}">{{ form.response_file.label }}</label>
-        {{ form.response_file }}
-        {% if form.response_file.errors %}
-            <div class="invalid-feedback d-block">{{ form.response_file.errors|join:", " }}</div>
-        {% endif %}
-    </div>
-
-    <button type="submit" class="btn btn-primary w-100">Submit response</button>
+  <button type="submit" class="btn btn-dark w-100">Submit response</button>
 </form>

--- a/templates/merchant/partials/_response_form.html
+++ b/templates/merchant/partials/_response_form.html
@@ -1,0 +1,28 @@
+<!--path: templates/merchant/partials/_response_form.html-->
+<form method="post" enctype="multipart/form-data" novalidate>
+    {% csrf_token %}
+
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger" role="alert">
+            {{ form.non_field_errors }}
+        </div>
+    {% endif %}
+
+    <div class="mb-3">
+        <label class="form-label" for="{{ form.response_note.id_for_label }}">{{ form.response_note.label }}</label>
+        {{ form.response_note }}
+        {% if form.response_note.errors %}
+            <div class="invalid-feedback d-block">{{ form.response_note.errors|join:", " }}</div>
+        {% endif %}
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label" for="{{ form.response_file.id_for_label }}">{{ form.response_file.label }}</label>
+        {{ form.response_file }}
+        {% if form.response_file.errors %}
+            <div class="invalid-feedback d-block">{{ form.response_file.errors|join:", " }}</div>
+        {% endif %}
+    </div>
+
+    <button type="submit" class="btn btn-primary w-100">Submit response</button>
+</form>

--- a/tests/test_merchant_portal_service.py
+++ b/tests/test_merchant_portal_service.py
@@ -11,7 +11,7 @@ from returns.models import EvidenceDocument
 from returns.services.merchant_portal import (
     build_merchant_case_page,
     get_merchant_case_for_user,
-    upload_merchant_response,
+    submit_merchant_response,
 )
 from tests.factories import (
     CaseEventFactory,
@@ -75,8 +75,31 @@ def test_get_merchant_case_for_user_filters_customer_only_documents() -> None:
 
 
 @pytest.mark.django_db
-def test_upload_merchant_response_uses_canonical_document_service(monkeypatch) -> None:
-    """Merchant response uploads should delegate to the shared document workflow."""
+def test_submit_merchant_response_allows_note_only_event_capture() -> None:
+    """Note-only merchant responses should append an event without creating a document."""
+
+    return_case = ReturnCaseFactory()
+    merchant_user = return_case.merchant.user
+    add_group(merchant_user, "merchant")
+
+    document = submit_merchant_response(
+        return_case,
+        merchant_user,
+        response_note="Warehouse inspection completed.",
+    )
+
+    event = return_case.events.get(event_type="merchant_response_submitted")
+
+    assert document is None
+    assert event.actor == merchant_user
+    assert event.actor_role == EvidenceDocument.ActorRole.MERCHANT
+    assert event.payload["response_note"] == "Warehouse inspection completed."
+    assert event.payload["has_document"] is False
+
+
+@pytest.mark.django_db
+def test_submit_merchant_response_uses_canonical_document_service(monkeypatch) -> None:
+    """Merchant file responses should delegate document persistence to the shared workflow."""
 
     return_case = ReturnCaseFactory()
     merchant_user = return_case.merchant.user
@@ -88,12 +111,14 @@ def test_upload_merchant_response_uses_canonical_document_service(monkeypatch) -
         lambda *args, **kwargs: None,
     )
 
-    document = upload_merchant_response(
+    document = submit_merchant_response(
         return_case,
         merchant_user,
-        uploaded_file,
-        description="Inspection notes attached",
+        response_note="Inspection notes attached",
+        response_file=uploaded_file,
     )
+
+    event = return_case.events.get(event_type="merchant_response_submitted")
 
     assert document.kind == EvidenceDocument.DocumentKind.RESPONSE
     assert document.actor_role == EvidenceDocument.ActorRole.MERCHANT
@@ -101,6 +126,9 @@ def test_upload_merchant_response_uses_canonical_document_service(monkeypatch) -
     assert document.visible_to_customer is False
     assert document.visible_to_merchant is True
     assert return_case.events.filter(event_type="document_uploaded").count() == 1
+    assert event.payload["response_note"] == "Inspection notes attached"
+    assert event.payload["document_id"] == str(document.pk)
+    assert event.payload["has_document"] is True
 
 
 @pytest.mark.django_db

--- a/tests/test_merchant_portal_views.py
+++ b/tests/test_merchant_portal_views.py
@@ -108,43 +108,41 @@ def test_merchant_case_detail_view_renders_for_linked_merchant(client, db) -> No
     assert b"Merchant response" in response.content
 
 
-def test_merchant_case_detail_post_redirects_after_successful_upload(
+def test_merchant_case_detail_post_redirects_after_note_only_submission(
     client,
     db,
     monkeypatch,
 ) -> None:
-    """Valid merchant uploads should redirect back to the merchant case detail page."""
+    """Valid note-only merchant responses should redirect back to the detail page."""
 
     return_case = ReturnCaseFactory(order_reference="MERCH-UPLOAD-001")
     add_group(return_case.merchant.user, "merchant")
 
     captured = {}
 
-    def fake_upload_merchant_response(
+    def fake_submit_merchant_response(
         *,
         return_case,
-        uploaded_by,
-        uploaded_file,
-        description,
+        submitted_by,
+        response_note,
+        response_file,
     ):
         captured["case"] = return_case
-        captured["uploaded_by"] = uploaded_by
-        captured["filename"] = uploaded_file.name
-        captured["description"] = description
+        captured["submitted_by"] = submitted_by
+        captured["response_note"] = response_note
+        captured["response_file"] = response_file
         return None
 
     monkeypatch.setattr(
-        "returns.views_merchant.upload_merchant_response",
-        fake_upload_merchant_response,
+        "returns.views_merchant.submit_merchant_response",
+        fake_submit_merchant_response,
     )
 
     client.force_login(return_case.merchant.user)
     response = client.post(
         reverse("merchant_portal:case_detail", kwargs={"case_id": return_case.pk}),
         data={
-            "kind": "response",
-            "notes": "Inspection complete",
-            "file": SimpleUploadedFile("response.jpg", b"jpg", content_type="image/jpeg"),
+            "response_note": "Inspection complete",
         },
     )
 
@@ -155,16 +153,16 @@ def test_merchant_case_detail_post_redirects_after_successful_upload(
     )
     assert captured == {
         "case": return_case,
-        "uploaded_by": return_case.merchant.user,
-        "filename": "response.jpg",
-        "description": "Inspection complete",
+        "submitted_by": return_case.merchant.user,
+        "response_note": "Inspection complete",
+        "response_file": None,
     }
     messages = [message.message for message in get_messages(response.wsgi_request)]
-    assert "Response uploaded successfully." in messages
+    assert "Response submitted successfully." in messages
 
 
-def test_merchant_can_upload_response_to_owned_case(client, db, monkeypatch) -> None:
-    """Posting a response file should create a document and a case event."""
+def test_merchant_can_submit_note_and_file_to_owned_case(client, db, monkeypatch) -> None:
+    """Posting a note and file should create both document and merchant response events."""
 
     return_case = ReturnCaseFactory(order_reference="MERCH-UPLOAD-REAL-001")
     add_group(return_case.merchant.user, "merchant")
@@ -177,9 +175,8 @@ def test_merchant_can_upload_response_to_owned_case(client, db, monkeypatch) -> 
     response = client.post(
         reverse("merchant_portal:case_detail", kwargs={"case_id": return_case.pk}),
         data={
-            "kind": EvidenceDocument.DocumentKind.RESPONSE,
-            "notes": "Response document attached.",
-            "file": SimpleUploadedFile(
+            "response_note": "Response document attached.",
+            "response_file": SimpleUploadedFile(
                 "response.jpg",
                 b"binary-image-content",
                 content_type="image/jpeg",
@@ -202,10 +199,48 @@ def test_merchant_can_upload_response_to_owned_case(client, db, monkeypatch) -> 
         ).count()
         == 1
     )
+    assert (
+        CaseEvent.objects.filter(
+            return_case=return_case,
+            event_type="merchant_response_submitted",
+        ).count()
+        == 1
+    )
+
+
+def test_merchant_can_submit_note_only_to_owned_case(client, db) -> None:
+    """Posting only a note should append a merchant response event without a document."""
+
+    return_case = ReturnCaseFactory(order_reference="MERCH-NOTE-ONLY-001")
+    add_group(return_case.merchant.user, "merchant")
+
+    client.force_login(return_case.merchant.user)
+    response = client.post(
+        reverse("merchant_portal:case_detail", kwargs={"case_id": return_case.pk}),
+        data={
+            "response_note": "Awaiting carrier confirmation before next step.",
+        },
+    )
+
+    assert response.status_code == 302
+    assert (
+        EvidenceDocument.objects.filter(
+            return_case=return_case,
+            kind=EvidenceDocument.DocumentKind.RESPONSE,
+        ).count()
+        == 0
+    )
+    assert (
+        CaseEvent.objects.filter(
+            return_case=return_case,
+            event_type="merchant_response_submitted",
+        ).count()
+        == 1
+    )
 
 
 def test_merchant_case_detail_post_renders_errors_for_invalid_upload(client, db) -> None:
-    """Invalid merchant uploads should re-render the page with a 400 status."""
+    """Blank merchant responses should re-render the page with a 400 status."""
 
     return_case = ReturnCaseFactory(order_reference="MERCH-UPLOAD-002")
     add_group(return_case.merchant.user, "merchant")
@@ -213,12 +248,12 @@ def test_merchant_case_detail_post_renders_errors_for_invalid_upload(client, db)
     client.force_login(return_case.merchant.user)
     response = client.post(
         reverse("merchant_portal:case_detail", kwargs={"case_id": return_case.pk}),
-        data={"kind": "response", "notes": "Missing file"},
+        data={},
     )
 
     assert response.status_code == 400
     assert b"Merchant response" in response.content
-    assert b"This field is required." in response.content
+    assert b"Add a response note, a supporting file, or both." in response.content
 
 
 def test_merchant_cannot_open_another_merchants_case(client, db) -> None:

--- a/tests/test_merchant_portal_views.py
+++ b/tests/test_merchant_portal_views.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from django.contrib.auth.models import Group
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import resolve, reverse
+from django.utils import timezone
 
 from returns.models import CaseEvent, EvidenceDocument
-from tests.factories import ReturnCaseFactory
+from tests.factories import CaseEventFactory, ReturnCaseFactory
 
 
 def add_group(user, group_name: str) -> None:
@@ -96,6 +99,34 @@ def test_merchant_case_detail_view_renders_for_linked_merchant(client, db) -> No
 
     return_case = ReturnCaseFactory(order_reference="MERCH-DETAIL-001")
     add_group(return_case.merchant.user, "merchant")
+    older_event = CaseEventFactory(
+        return_case=return_case,
+        actor=return_case.merchant.user,
+        actor_role="merchant",
+        event_type="merchant_response_submitted",
+        payload={
+            "response_note": "Initial warehouse check complete.",
+            "document_id": "",
+            "document_kind": "",
+            "has_document": False,
+        },
+    )
+    latest_event = CaseEventFactory(
+        return_case=return_case,
+        actor=return_case.merchant.user,
+        actor_role="merchant",
+        event_type="merchant_response_submitted",
+        payload={
+            "response_note": "Escalated to carrier with supporting evidence.",
+            "document_id": "123",
+            "document_kind": "response",
+            "has_document": True,
+        },
+    )
+    CaseEvent.objects.filter(pk=older_event.pk).update(
+        created_at=timezone.now() - timedelta(days=1)
+    )
+    CaseEvent.objects.filter(pk=latest_event.pk).update(created_at=timezone.now())
 
     client.force_login(return_case.merchant.user)
     response = client.get(
@@ -106,6 +137,10 @@ def test_merchant_case_detail_view_renders_for_linked_merchant(client, db) -> No
     assert b"Merchant Case Workspace" in response.content
     assert b"MERCH-DETAIL-001" in response.content
     assert b"Merchant response" in response.content
+    assert b"Latest merchant response" in response.content
+    assert b"Response history" in response.content
+    assert b"Merchant Activity" in response.content
+    assert b"Escalated to carrier with supporting evidence." in response.content
 
 
 def test_merchant_case_detail_post_redirects_after_note_only_submission(


### PR DESCRIPTION
**Summary**
Adds a merchant-specific response submission flow that supports note-only responses, file-backed responses, and append-only merchant activity capture within the merchant portal.

**Changes**
- added a dedicated `MerchantResponseForm` for merchant note and file submissions
- refactored merchant detail handling to use the merchant-specific response form instead of the shared customer-style upload contract
- added merchant response service logic that always appends a `merchant_response_submitted` event
- preserved shared document persistence by routing file-backed submissions through the canonical document upload service
- enabled note-only merchant responses without requiring a file attachment
- enabled file-plus-note merchant responses with shared `EvidenceDocument` creation and `document_uploaded` event capture
- added merchant dashboard context for latest response summary, response history, and merchant-scoped activity
- expanded the merchant case detail UI with response summary panels and a clearer merchant activity section
- aligned the merchant response partial with current shared UI conventions and template styling
- added merchant portal service and view coverage for note-only submissions, file-backed submissions, route behavior, access scoping, and dashboard rendering

**Why**
The merchant portal needed behavior that is denser and more operational than the customer portal while still preserving the shared ReturnHub structure. Merchants need to submit contextual responses without being forced into file-only workflows, and the merchant dashboard needs an append-only event trail that can surface the latest response, response history, and merchant-side activity clearly.

**Validation**
- `docker compose exec web pytest tests/test_merchant_portal_service.py tests/test_merchant_portal_views.py -q`
- `docker compose exec web python -m black returns/forms_merchant.py returns/services/merchant_portal.py returns/views_merchant.py tests/test_merchant_portal_service.py tests/test_merchant_portal_views.py --check`
- `docker compose exec web python -m ruff check returns/forms_merchant.py returns/services/merchant_portal.py returns/views_merchant.py tests/test_merchant_portal_service.py tests/test_merchant_portal_views.py`

**Result**
- merchant portal now supports note-only and file-plus-note response submission flows
- each merchant submission now produces append-only event capture for dashboard use
- merchant detail UI now exposes latest response summary, response history, and merchant-specific activity signals
- merchant service and view coverage passed: `14 passed`
- targeted lint and formatting checks passed

**Notes**
- the merchant flow preserves shared routing, access control, layout structure, and canonical document persistence where files are involved
- the live event contract for the merchant dashboard is `CaseEvent.event_type == "merchant_response_submitted"`
- file-backed merchant submissions still emit the shared `document_uploaded` event through the canonical document workflow