### PR TITLE
test(returns): align merchant portal view tests with integration coverage

### DIFF
--- a/tests/test_merchant_portal_views.py
+++ b/tests/test_merchant_portal_views.py
@@ -1,9 +1,10 @@
-"""Tests for merchant portal routes and views."""
+"""Integration tests for merchant portal views."""
 
 from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
 from django.contrib.auth.models import Group
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -12,6 +13,8 @@ from django.utils import timezone
 
 from returns.models import CaseEvent, EvidenceDocument
 from tests.factories import CaseEventFactory, ReturnCaseFactory
+
+pytestmark = pytest.mark.django_db
 
 
 def add_group(user, group_name: str) -> None:


### PR DESCRIPTION
**Summary**
Aligns merchant portal view tests with the project’s integration-style coverage while preserving the live ReturnHub contracts for merchant routing, response submission, and dashboard behavior.

**Changes**
- updated the merchant portal view test module to use integration-test framing
- added a module-level Django DB marker for the merchant portal view test file
- preserved the live merchant portal route assertions for `/merchant/` and `/merchant/<case_id>/`
- preserved merchant list coverage for pagination behavior and merchant ownership scoping
- preserved merchant detail coverage for linked-merchant access and cross-merchant 404 behavior
- preserved merchant response submission coverage for note-only submissions and note-plus-file submissions
- preserved merchant event coverage for `merchant_response_submitted` and shared `document_uploaded` behavior
- preserved merchant dashboard rendering coverage for latest response, response history, and merchant activity panels
- avoided merging stale `apps.*` import paths and obsolete route/document assumptions from the legacy test variant

**Why**
A stale integration-style merchant portal test file existed in a shape that did not match this repository’s actual structure or live contracts. This update brings the merchant portal tests into the intended integration-style framing without regressing to stale module paths, `pk` route assumptions, or the obsolete `merchant_response` document kind.

**Validation**
- `docker compose exec web pytest tests/test_merchant_portal_views.py -q`

**Result**
- merchant portal view tests passed: `9 passed`
- merchant portal test coverage remains aligned with the live `case_id` route contract
- merchant portal integration coverage remains aligned with note-only responses, file-backed responses, and merchant dashboard behavior

**Notes**
- the merged test file keeps the project’s real `returns.*` imports rather than the stale `apps.*` layout
- the live response contract remains `EvidenceDocument.DocumentKind.RESPONSE`
- the live merchant dashboard event contract remains `CaseEvent.event_type == "merchant_response_submitted"`