### PR TITLE
Feat/add role aware app navigation

### DIFF
--- a/accounts/templatetags/__init__.py
+++ b/accounts/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Custom template tags for the accounts app."""

--- a/accounts/templatetags/surface_access.py
+++ b/accounts/templatetags/surface_access.py
@@ -1,0 +1,31 @@
+# path: accounts/templatetags/surface_access.py
+"""Template tags for surface-aware navigation and access checks."""
+
+from django import template
+
+from apps.accounts.constants import GROUP_NAMES, ROLE_ADMIN, ROLE_CUSTOMER, ROLE_MERCHANT, ROLE_OPS
+from apps.accounts.mixins import is_admin_user, user_in_group, user_has_surface_access
+
+register = template.Library()
+
+
+@register.filter
+def has_group(user, role):
+    """Return True when the user belongs to the requested role group."""
+    if role not in GROUP_NAMES:
+        return False
+    return user_in_group(user, GROUP_NAMES[role])
+
+
+@register.filter
+def can_access_surface(user, role):
+    """Return True when the user may access the requested surface."""
+    if role not in {ROLE_ADMIN, ROLE_OPS, ROLE_CUSTOMER, ROLE_MERCHANT}:
+        return False
+    return user_has_surface_access(user, role)
+
+
+@register.simple_tag
+def is_admin_surface_user(user):
+    """Return True when the current user is an admin."""
+    return is_admin_user(user)

--- a/accounts/templatetags/surface_access.py
+++ b/accounts/templatetags/surface_access.py
@@ -1,10 +1,15 @@
-# path: accounts/templatetags/surface_access.py
 """Template tags for surface-aware navigation and access checks."""
 
 from django import template
 
-from apps.accounts.constants import GROUP_NAMES, ROLE_ADMIN, ROLE_CUSTOMER, ROLE_MERCHANT, ROLE_OPS
-from apps.accounts.mixins import is_admin_user, user_in_group, user_has_surface_access
+from accounts.constants import (
+    GROUP_NAMES,
+    ROLE_ADMIN,
+    ROLE_CUSTOMER,
+    ROLE_MERCHANT,
+    ROLE_OPS,
+)
+from accounts.mixins import is_admin_user, user_in_group, user_has_surface_access
 
 register = template.Library()
 
@@ -12,6 +17,7 @@ register = template.Library()
 @register.filter
 def has_group(user, role):
     """Return True when the user belongs to the requested role group."""
+
     if role not in GROUP_NAMES:
         return False
     return user_in_group(user, GROUP_NAMES[role])
@@ -20,6 +26,7 @@ def has_group(user, role):
 @register.filter
 def can_access_surface(user, role):
     """Return True when the user may access the requested surface."""
+
     if role not in {ROLE_ADMIN, ROLE_OPS, ROLE_CUSTOMER, ROLE_MERCHANT}:
         return False
     return user_has_surface_access(user, role)

--- a/accounts/templatetags/surface_access.py
+++ b/accounts/templatetags/surface_access.py
@@ -9,7 +9,11 @@ from accounts.constants import (
     ROLE_MERCHANT,
     ROLE_OPS,
 )
-from accounts.mixins import is_admin_user, user_in_group, user_has_surface_access
+from accounts.mixins import (
+    is_admin_user,
+    user_has_surface_access,
+    user_in_group,
+)
 
 register = template.Library()
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -58,6 +58,9 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "common.context_processors.app_shell",
             ],
+            "libraries": {
+                "surface_access": "accounts.templatetags.surface_access",
+            },
         },
     }
 ]

--- a/templates/partials/_app_nav.html
+++ b/templates/partials/_app_nav.html
@@ -42,10 +42,6 @@
         <a class="btn btn-outline-secondary btn-sm rh-topbar-secondary" href="{% url 'accounts:logout' %}">
           Sign out
         </a>
-      {% else %}
-        <a class="btn btn-dark btn-sm rh-topbar-primary" href="{% url 'accounts:login_merchant' %}">
-          Sign in
-        </a>
       {% endif %}
     </div>
   </div>

--- a/templates/partials/_app_nav.html
+++ b/templates/partials/_app_nav.html
@@ -1,18 +1,52 @@
-<!-- path: templates/partials/_app_nav.html -->
-<nav class="navbar navbar-expand-lg rh-topbar">
+{% load surface_access %}
+
+<nav class="rh-topbar" aria-label="Primary">
   <div class="container rh-topbar-inner">
     <a class="rh-brand" href="{% url 'landing' %}">
       <span class="rh-brand-mark" aria-hidden="true">R</span>
-      <span>{{ brand_name }}</span>
+      <span>{{ brand_name|default:"ReturnHub" }}</span>
     </a>
-    <div class="rh-topbar-links" aria-label="Primary">
+
+    <div class="rh-topbar-links">
       <a href="{% url 'landing' %}#how-it-works">How it works</a>
       <a href="{% url 'landing' %}#workflow">Workflow</a>
-      <a href="{% url 'admin-login' %}">Admin</a>
-      <a href="{% url 'ops-login' %}">Ops</a>
-      <a href="{% url 'customer-login' %}">Customer</a>
-      <a href="{% url 'merchant-login' %}">Merchant</a>
+
+      {% if request.user.is_authenticated %}
+        {% if request.user|can_access_surface:"admin" %}
+          <a href="{% url 'accounts:console_admin' %}">Admin</a>
+        {% endif %}
+        {% if request.user|can_access_surface:"ops" %}
+          <a href="{% url 'ops:queue' %}">Ops</a>
+        {% endif %}
+        {% if request.user|can_access_surface:"customer" %}
+          <a href="{% url 'customer_portal:case_list' %}">Customer</a>
+        {% endif %}
+        {% if request.user|can_access_surface:"merchant" %}
+          <a href="{% url 'merchant_portal:case_list' %}">Merchant</a>
+        {% endif %}
+      {% else %}
+        <a href="{% url 'accounts:login_admin' %}">Admin</a>
+        <a href="{% url 'accounts:login_ops' %}">Ops</a>
+        <a href="{% url 'accounts:login_customer' %}">Customer</a>
+        <a href="{% url 'accounts:login_merchant' %}">Merchant</a>
+      {% endif %}
+
       <a href="{% url 'landing' %}#support">Support</a>
+    </div>
+
+    <div class="rh-topbar-actions">
+      {% if request.user.is_authenticated %}
+        <div class="rh-topbar-meta" aria-label="Signed-in user">
+          <span class="rh-header-note">{{ request.user.get_username }}</span>
+        </div>
+        <a class="btn btn-outline-secondary btn-sm rh-topbar-secondary" href="{% url 'accounts:logout' %}">
+          Sign out
+        </a>
+      {% else %}
+        <a class="btn btn-dark btn-sm rh-topbar-primary" href="{% url 'accounts:login_merchant' %}">
+          Sign in
+        </a>
+      {% endif %}
     </div>
   </div>
 </nav>

--- a/tests/test_surface_access_templatetags.py
+++ b/tests/test_surface_access_templatetags.py
@@ -1,0 +1,70 @@
+"""Tests for surface access template tags."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import AnonymousUser, Group
+
+from accounts.templatetags.surface_access import (
+    can_access_surface,
+    has_group,
+    is_admin_surface_user,
+)
+from tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def add_group(user, group_name: str) -> None:
+    """Attach a Django group to a user for test setup."""
+
+    group, _ = Group.objects.get_or_create(name=group_name)
+    user.groups.add(group)
+
+
+def test_has_group_returns_true_for_matching_role_group() -> None:
+    """The template filter should confirm membership for valid mapped roles."""
+
+    merchant_user = UserFactory()
+    add_group(merchant_user, "merchant")
+
+    assert has_group(merchant_user, "merchant") is True
+
+
+def test_has_group_returns_false_for_unknown_role() -> None:
+    """The template filter should reject unknown role keys."""
+
+    user = UserFactory()
+
+    assert has_group(user, "unknown") is False
+
+
+def test_can_access_surface_returns_true_for_allowed_surface() -> None:
+    """The template filter should mirror the shared surface access helper."""
+
+    customer_user = UserFactory()
+    add_group(customer_user, "customer")
+
+    assert can_access_surface(customer_user, "customer") is True
+
+
+def test_can_access_surface_returns_false_for_unknown_surface() -> None:
+    """Unknown surface names should be rejected by the template filter."""
+
+    user = UserFactory()
+
+    assert can_access_surface(user, "unknown") is False
+
+
+def test_is_admin_surface_user_returns_true_for_superuser() -> None:
+    """The simple tag should identify admin-capable users."""
+
+    admin_user = UserFactory(is_superuser=True, is_staff=True)
+
+    assert is_admin_surface_user(admin_user) is True
+
+
+def test_is_admin_surface_user_returns_false_for_anonymous_user() -> None:
+    """Anonymous users should never be treated as admin-capable."""
+
+    assert is_admin_surface_user(AnonymousUser()) is False


### PR DESCRIPTION
**Summary**
Adds role-aware application navigation that exposes the correct ReturnHub surfaces for each user while keeping the shared topbar aligned with the project’s `rh-*` UI system.

**Changes**
- added surface-aware template tags for navigation and access checks in `accounts/templatetags/surface_access.py`
- registered the `surface_access` template tag library in Django template settings so it can be loaded reliably
- refactored the shared app navigation partial to use the project’s existing `rh-topbar` structure and styling
- updated the topbar to render role-aware surface links for authenticated users
- updated the topbar to render surface login links for anonymous users
- replaced hardcoded navigation paths with `{% url %}` usage throughout the app nav
- surfaced authenticated user metadata and sign-out action in the shared nav
- removed the duplicated anonymous merchant sign-in CTA from the nav once surface links were already present
- kept the app navigation wired through the shared `base.html` layout

**Why**
The project needed a single shared navigation layer that respects role-based surface access without embedding brittle group logic directly in templates. This change centralizes access checks in template tags, keeps navigation aligned with the live route structure, and makes the topbar reflect the actual ReturnHub surface model for admins, ops, customers, and merchants.

**Validation**
- verified the `surface_access` template tag library resolves through Django template settings
- verified the shared app nav is included through `base.html`
- verified anonymous navigation exposes the expected surface entry links
- verified authenticated navigation uses surface-aware access checks instead of brittle inline group checks

**Result**
- ReturnHub now has a role-aware shared topbar
- templates can use surface access tags instead of hardcoded group logic
- anonymous users see surface entry links without a duplicated merchant sign-in button
- authenticated users see only the surfaces they can actually access

**Notes**
- the navigation now prefers `can_access_surface` for template-level access checks
- the `surface_access` library was aligned to the repo’s real `accounts.*` module structure, not the stale `apps.*` layout
- `base.html` remained the single wiring point for the shared app nav