### PR TITLE
fix(ui): replace admin fallback with sign-in CTA on error pages

### DIFF
--- a/templates/errors/403.html
+++ b/templates/errors/403.html
@@ -16,7 +16,7 @@
         </p>
         <div class="rh-hero-actions">
           <a class="btn btn-primary rh-btn-primary" href="{% url 'landing' %}">Return to landing page</a>
-          <a class="btn btn-outline-secondary rh-btn-secondary" href="/admin/">Open Django admin</a>
+          <a class="btn btn-outline-secondary rh-btn-secondary" href="{% url 'accounts:login_merchant' %}">Go to sign in</a>
         </div>
       </div>
       <aside class="rh-hero-visual" aria-label="Access restriction summary">

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -15,7 +15,7 @@
         </p>
         <div class="rh-hero-actions">
           <a class="btn btn-primary rh-btn-primary" href="{% url 'landing' %}">Return to landing page</a>
-          <a class="btn btn-outline-secondary rh-btn-secondary" href="/admin/">Open Django admin</a>
+          <a class="btn btn-outline-secondary rh-btn-secondary" href="{% url 'accounts:login_merchant' %}">Go to sign in</a>
         </div>
       </div>
       <aside class="rh-hero-visual" aria-label="Not found summary">

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -15,7 +15,7 @@
         </p>
         <div class="rh-hero-actions">
           <a class="btn btn-primary rh-btn-primary" href="{% url 'landing' %}">Return to landing page</a>
-          <a class="btn btn-outline-secondary rh-btn-secondary" href="/admin/">Open Django admin</a>
+          <a class="btn btn-outline-secondary rh-btn-secondary" href="{% url 'accounts:login_merchant' %}">Go to sign in</a>
         </div>
       </div>
       <aside class="rh-hero-visual" aria-label="Server error summary">


### PR DESCRIPTION
**Summary**
Replaces the admin-oriented fallback action on shared error pages with a public sign-in CTA so recovery paths stay role-safe and aligned with the broader ReturnHub product experience.

**Changes**
- updated `templates/errors/403.html` to replace `Open Django admin` with `Go to sign in`
- updated `templates/errors/404.html` to replace `Open Django admin` with `Go to sign in`
- updated `templates/errors/500.html` to replace `Open Django admin` with `Go to sign in`
- preserved the existing `Return to landing page` primary action on all shared error templates
- kept the branded error layout, tone, and shared `rh-*` UI structure intact

**Why**
The previous fallback action was technically valid, but it exposed an admin-oriented recovery path on shared public error pages used by customers, merchants, ops users, and anonymous visitors. Replacing it with a sign-in CTA keeps the recovery path broadly useful, better matches ReturnHub’s role-entry model, and avoids surfacing Django admin as the default fallback for non-admin audiences.

**Validation**
- verified `templates/errors/403.html`, `404.html`, and `500.html` now point to `accounts:login_merchant` for the secondary CTA
- confirmed the primary landing-page recovery action remains unchanged
- confirmed the shared error handlers remain wired through `ui.error_views` and `config/urls.py`

**Result**
- shared error pages now present a role-safe recovery action
- the error experience remains branded and consistent with the rest of ReturnHub
- users are directed toward sign-in rather than an admin-only fallback path

**Notes**
- this change is UX-oriented rather than infrastructural; the previous admin link was wired correctly
- authenticated users still have clear access to allowed surfaces through the shared role-aware app navigation
- if desired later, the sign-in CTA could be made even more context-aware by routing to a surface chooser rather than a single sign-in entry