### PR TITLE
Feat/create deterministic multi surface demo seed

### DIFF
--- a/returns/management/__init__.py
+++ b/returns/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management command package for the returns app."""

--- a/returns/management/commands/__init__.py
+++ b/returns/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Custom management commands for the returns app."""

--- a/returns/management/commands/seed_returnhub_demo.py
+++ b/returns/management/commands/seed_returnhub_demo.py
@@ -64,37 +64,29 @@ class Command(BaseCommand):
             role=ROLE_MERCHANT,
         )
 
-        customer_one = CustomerProfile.objects.update_or_create(
+        customer_one = self._ensure_customer_profile(
             user=customer_one_user,
-            defaults={
-                "external_reference": "CUS-DEMO-0001",
-                "display_name": "Customer One",
-            },
-        )[0]
-        customer_two = CustomerProfile.objects.update_or_create(
+            external_reference="CUS-DEMO-0001",
+            display_name="Customer One",
+        )
+        customer_two = self._ensure_customer_profile(
             user=customer_two_user,
-            defaults={
-                "external_reference": "CUS-DEMO-0002",
-                "display_name": "Customer Two",
-            },
-        )[0]
+            external_reference="CUS-DEMO-0002",
+            display_name="Customer Two",
+        )
 
-        merchant_one = MerchantProfile.objects.update_or_create(
+        merchant_one = self._ensure_merchant_profile(
             user=merchant_one_user,
-            defaults={
-                "merchant_code": "MER-DEMO-0001",
-                "display_name": "Merchant One",
-                "support_email": "merchant.one@returnhub.local",
-            },
-        )[0]
-        merchant_two = MerchantProfile.objects.update_or_create(
+            merchant_code="MER-DEMO-0001",
+            display_name="Merchant One",
+            support_email="merchant.one@returnhub.local",
+        )
+        merchant_two = self._ensure_merchant_profile(
             user=merchant_two_user,
-            defaults={
-                "merchant_code": "MER-DEMO-0002",
-                "display_name": "Merchant Two",
-                "support_email": "merchant.two@returnhub.local",
-            },
-        )[0]
+            merchant_code="MER-DEMO-0002",
+            display_name="Merchant Two",
+            support_email="merchant.two@returnhub.local",
+        )
 
         self._ensure_cases(customer_one, merchant_one, start_index=1, count=16)
         self._ensure_cases(customer_two, merchant_two, start_index=17, count=16)
@@ -127,6 +119,61 @@ class Command(BaseCommand):
         group = Group.objects.get(name=GROUP_NAMES[role])
         user.groups.set([group])
         return user
+
+    def _ensure_customer_profile(self, *, user, external_reference, display_name):
+        """Create or update a customer profile without colliding on unique references."""
+
+        profile = CustomerProfile.objects.filter(user=user).first()
+        if profile is None:
+            profile = CustomerProfile.objects.filter(external_reference=external_reference).first()
+        if profile is None:
+            profile = CustomerProfile(
+                user=user,
+                external_reference=external_reference,
+            )
+
+        conflicting_profile = (
+            CustomerProfile.objects.filter(external_reference=external_reference)
+            .exclude(pk=profile.pk)
+            .first()
+        )
+        if conflicting_profile is not None:
+            conflicting_profile.external_reference = f"legacy-cus-{conflicting_profile.pk}"
+            conflicting_profile.save()
+
+        profile.user = user
+        profile.external_reference = external_reference
+        profile.display_name = display_name
+        profile.save()
+        return profile
+
+    def _ensure_merchant_profile(self, *, user, merchant_code, display_name, support_email):
+        """Create or update a merchant profile without colliding on unique merchant codes."""
+
+        profile = MerchantProfile.objects.filter(user=user).first()
+        if profile is None:
+            profile = MerchantProfile.objects.filter(merchant_code=merchant_code).first()
+        if profile is None:
+            profile = MerchantProfile(
+                user=user,
+                merchant_code=merchant_code,
+            )
+
+        conflicting_profile = (
+            MerchantProfile.objects.filter(merchant_code=merchant_code)
+            .exclude(pk=profile.pk)
+            .first()
+        )
+        if conflicting_profile is not None:
+            conflicting_profile.merchant_code = f"legacy-mer-{conflicting_profile.pk}"
+            conflicting_profile.save()
+
+        profile.user = user
+        profile.merchant_code = merchant_code
+        profile.display_name = display_name
+        profile.support_email = support_email
+        profile.save()
+        return profile
 
     def _ensure_cases(self, customer, merchant, start_index, count):
         """Create or update a fixed block of deterministic return cases."""

--- a/returns/management/commands/seed_returnhub_demo.py
+++ b/returns/management/commands/seed_returnhub_demo.py
@@ -1,15 +1,17 @@
-# path: returns/management/commands/seed_returnhub_demo.py
 """Seed a deterministic multi-surface demo environment for ReturnHub."""
 
-from datetime import timedelta
+from __future__ import annotations
+
+from datetime import date, timedelta
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from apps.accounts.constants import GROUP_NAMES, ROLE_ADMIN, ROLE_CUSTOMER, ROLE_MERCHANT, ROLE_OPS
-from apps.returns.models import CustomerProfile, MerchantProfile, ReturnCase
+from accounts.constants import GROUP_NAMES, ROLE_ADMIN, ROLE_CUSTOMER, ROLE_MERCHANT, ROLE_OPS
+from accounts.models import CustomerProfile, MerchantProfile
+from returns.models import ReturnCase
 
 User = get_user_model()
 
@@ -64,20 +66,34 @@ class Command(BaseCommand):
 
         customer_one = CustomerProfile.objects.update_or_create(
             user=customer_one_user,
-            defaults={"full_name": "Customer One"},
+            defaults={
+                "external_reference": "CUS-DEMO-0001",
+                "display_name": "Customer One",
+            },
         )[0]
         customer_two = CustomerProfile.objects.update_or_create(
             user=customer_two_user,
-            defaults={"full_name": "Customer Two"},
+            defaults={
+                "external_reference": "CUS-DEMO-0002",
+                "display_name": "Customer Two",
+            },
         )[0]
 
         merchant_one = MerchantProfile.objects.update_or_create(
             user=merchant_one_user,
-            defaults={"name": "Merchant One"},
+            defaults={
+                "merchant_code": "MER-DEMO-0001",
+                "display_name": "Merchant One",
+                "support_email": "merchant.one@returnhub.local",
+            },
         )[0]
         merchant_two = MerchantProfile.objects.update_or_create(
             user=merchant_two_user,
-            defaults={"name": "Merchant Two"},
+            defaults={
+                "merchant_code": "MER-DEMO-0002",
+                "display_name": "Merchant Two",
+                "support_email": "merchant.two@returnhub.local",
+            },
         )[0]
 
         self._ensure_cases(customer_one, merchant_one, start_index=1, count=16)
@@ -114,18 +130,33 @@ class Command(BaseCommand):
 
     def _ensure_cases(self, customer, merchant, start_index, count):
         """Create or update a fixed block of deterministic return cases."""
-        statuses = ["new", "awaiting_customer", "in_review", "resolved"]
+        statuses = [
+            ReturnCase.Status.SUBMITTED,
+            ReturnCase.Status.WAITING_CUSTOMER,
+            ReturnCase.Status.IN_REVIEW,
+            ReturnCase.Status.WAITING_MERCHANT,
+            ReturnCase.Status.APPROVED,
+            ReturnCase.Status.REJECTED,
+        ]
 
         for index in range(start_index, start_index + count):
             ReturnCase.objects.update_or_create(
-                reference=f"RH-{index:05d}",
+                order_reference=f"RH-{index:05d}",
                 defaults={
                     "customer": customer,
                     "merchant": merchant,
                     "status": statuses[(index - 1) % len(statuses)],
-                    "priority": "medium" if index % 2 == 0 else "high",
-                    "return_reason": "damaged_item" if index % 2 == 0 else "not_as_described",
+                    "priority": (
+                        ReturnCase.Priority.MEDIUM
+                        if index % 2 == 0
+                        else ReturnCase.Priority.HIGH
+                    ),
+                    "item_category": "electronics" if index % 2 == 0 else "apparel",
+                    "return_reason": "Damaged item" if index % 2 == 0 else "Not as described",
                     "customer_message": f"Demo case {index} for deterministic pagination coverage.",
+                    "order_value": "79.99" if index % 2 == 0 else "149.99",
+                    "delivery_date": date(2025, 12, 1) + timedelta(days=index),
                     "sla_due_at": timezone.now() + timedelta(days=2),
+                    "last_status_changed_at": timezone.now(),
                 },
             )

--- a/returns/management/commands/seed_returnhub_demo.py
+++ b/returns/management/commands/seed_returnhub_demo.py
@@ -1,0 +1,131 @@
+# path: returns/management/commands/seed_returnhub_demo.py
+"""Seed a deterministic multi-surface demo environment for ReturnHub."""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from apps.accounts.constants import GROUP_NAMES, ROLE_ADMIN, ROLE_CUSTOMER, ROLE_MERCHANT, ROLE_OPS
+from apps.returns.models import CustomerProfile, MerchantProfile, ReturnCase
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """Create stable users, profiles, and cases for the Sprint 6 multi-surface demo."""
+
+    help = "Seed deterministic users and paginated return cases for the ReturnHub demo."
+
+    def handle(self, *args, **options):
+        """Create demo users, groups, profiles, and enough cases for page 1 and page 2."""
+        self._ensure_groups()
+
+        admin_user = self._ensure_user(
+            username="admin.demo",
+            email="admin.demo@returnhub.local",
+            password="ChangeMe123!",
+            role=ROLE_ADMIN,
+            is_staff=True,
+            is_superuser=True,
+        )
+        ops_user = self._ensure_user(
+            username="ops.demo",
+            email="ops.demo@returnhub.local",
+            password="ChangeMe123!",
+            role=ROLE_OPS,
+        )
+        customer_one_user = self._ensure_user(
+            username="customer.one",
+            email="customer.one@returnhub.local",
+            password="ChangeMe123!",
+            role=ROLE_CUSTOMER,
+        )
+        customer_two_user = self._ensure_user(
+            username="customer.two",
+            email="customer.two@returnhub.local",
+            password="ChangeMe123!",
+            role=ROLE_CUSTOMER,
+        )
+        merchant_one_user = self._ensure_user(
+            username="merchant.one",
+            email="merchant.one@returnhub.local",
+            password="ChangeMe123!",
+            role=ROLE_MERCHANT,
+        )
+        merchant_two_user = self._ensure_user(
+            username="merchant.two",
+            email="merchant.two@returnhub.local",
+            password="ChangeMe123!",
+            role=ROLE_MERCHANT,
+        )
+
+        customer_one = CustomerProfile.objects.update_or_create(
+            user=customer_one_user,
+            defaults={"full_name": "Customer One"},
+        )[0]
+        customer_two = CustomerProfile.objects.update_or_create(
+            user=customer_two_user,
+            defaults={"full_name": "Customer Two"},
+        )[0]
+
+        merchant_one = MerchantProfile.objects.update_or_create(
+            user=merchant_one_user,
+            defaults={"name": "Merchant One"},
+        )[0]
+        merchant_two = MerchantProfile.objects.update_or_create(
+            user=merchant_two_user,
+            defaults={"name": "Merchant Two"},
+        )[0]
+
+        self._ensure_cases(customer_one, merchant_one, start_index=1, count=16)
+        self._ensure_cases(customer_two, merchant_two, start_index=17, count=16)
+
+        self.stdout.write(self.style.SUCCESS("ReturnHub demo seed complete."))
+        self.stdout.write(f"Admin user: {admin_user.username}")
+        self.stdout.write(f"Ops user: {ops_user.username}")
+        self.stdout.write(f"Customer users: {customer_one_user.username}, {customer_two_user.username}")
+        self.stdout.write(f"Merchant users: {merchant_one_user.username}, {merchant_two_user.username}")
+        self.stdout.write(f"Total cases: {ReturnCase.objects.count()}")
+
+    def _ensure_groups(self):
+        """Create required role groups if they do not already exist."""
+        for group_name in GROUP_NAMES.values():
+            Group.objects.get_or_create(name=group_name)
+
+    def _ensure_user(self, username, email, password, role, is_staff=False, is_superuser=False):
+        """Create or update a demo user and attach the correct group."""
+        user, _ = User.objects.update_or_create(
+            username=username,
+            defaults={
+                "email": email,
+                "is_staff": is_staff,
+                "is_superuser": is_superuser,
+            },
+        )
+        user.set_password(password)
+        user.save()
+
+        group = Group.objects.get(name=GROUP_NAMES[role])
+        user.groups.set([group])
+        return user
+
+    def _ensure_cases(self, customer, merchant, start_index, count):
+        """Create or update a fixed block of deterministic return cases."""
+        statuses = ["new", "awaiting_customer", "in_review", "resolved"]
+
+        for index in range(start_index, start_index + count):
+            ReturnCase.objects.update_or_create(
+                reference=f"RH-{index:05d}",
+                defaults={
+                    "customer": customer,
+                    "merchant": merchant,
+                    "status": statuses[(index - 1) % len(statuses)],
+                    "priority": "medium" if index % 2 == 0 else "high",
+                    "return_reason": "damaged_item" if index % 2 == 0 else "not_as_described",
+                    "customer_message": f"Demo case {index} for deterministic pagination coverage.",
+                    "sla_due_at": timezone.now() + timedelta(days=2),
+                },
+            )

--- a/returns/management/commands/seed_returnhub_demo.py
+++ b/returns/management/commands/seed_returnhub_demo.py
@@ -9,7 +9,13 @@ from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from accounts.constants import GROUP_NAMES, ROLE_ADMIN, ROLE_CUSTOMER, ROLE_MERCHANT, ROLE_OPS
+from accounts.constants import (
+    GROUP_NAMES,
+    ROLE_ADMIN,
+    ROLE_CUSTOMER,
+    ROLE_MERCHANT,
+    ROLE_OPS,
+)
 from accounts.models import CustomerProfile, MerchantProfile
 from returns.models import ReturnCase
 
@@ -94,17 +100,31 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("ReturnHub demo seed complete."))
         self.stdout.write(f"Admin user: {admin_user.username}")
         self.stdout.write(f"Ops user: {ops_user.username}")
-        self.stdout.write(f"Customer users: {customer_one_user.username}, {customer_two_user.username}")
-        self.stdout.write(f"Merchant users: {merchant_one_user.username}, {merchant_two_user.username}")
+        self.stdout.write(
+            f"Customer users: {customer_one_user.username}, {customer_two_user.username}"
+        )
+        self.stdout.write(
+            f"Merchant users: {merchant_one_user.username}, {merchant_two_user.username}"
+        )
         self.stdout.write(f"Total cases: {ReturnCase.objects.count()}")
 
     def _ensure_groups(self):
         """Create required role groups if they do not already exist."""
+
         for group_name in GROUP_NAMES.values():
             Group.objects.get_or_create(name=group_name)
 
-    def _ensure_user(self, username, email, password, role, is_staff=False, is_superuser=False):
+    def _ensure_user(
+        self,
+        username,
+        email,
+        password,
+        role,
+        is_staff=False,
+        is_superuser=False,
+    ):
         """Create or update a demo user and attach the correct group."""
+
         user, _ = User.objects.update_or_create(
             username=username,
             defaults={
@@ -147,7 +167,14 @@ class Command(BaseCommand):
         profile.save()
         return profile
 
-    def _ensure_merchant_profile(self, *, user, merchant_code, display_name, support_email):
+    def _ensure_merchant_profile(
+        self,
+        *,
+        user,
+        merchant_code,
+        display_name,
+        support_email,
+    ):
         """Create or update a merchant profile without colliding on unique merchant codes."""
 
         profile = MerchantProfile.objects.filter(user=user).first()
@@ -194,12 +221,10 @@ class Command(BaseCommand):
                     "merchant": merchant,
                     "status": statuses[(index - 1) % len(statuses)],
                     "priority": (
-                        ReturnCase.Priority.MEDIUM
-                        if index % 2 == 0
-                        else ReturnCase.Priority.HIGH
+                        ReturnCase.Priority.MEDIUM if index % 2 == 0 else ReturnCase.Priority.HIGH
                     ),
                     "item_category": "electronics" if index % 2 == 0 else "apparel",
-                    "return_reason": "Damaged item" if index % 2 == 0 else "Not as described",
+                    "return_reason": ("Damaged item" if index % 2 == 0 else "Not as described"),
                     "customer_message": f"Demo case {index} for deterministic pagination coverage.",
                     "order_value": "79.99" if index % 2 == 0 else "149.99",
                     "delivery_date": date(2025, 12, 1) + timedelta(days=index),

--- a/tests/test_seed_returnhub_demo_command.py
+++ b/tests/test_seed_returnhub_demo_command.py
@@ -1,0 +1,134 @@
+"""Tests for the seed_returnhub_demo management command."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+
+from accounts.models import CustomerProfile, MerchantProfile
+from returns.models import ReturnCase
+
+
+@pytest.mark.django_db
+def test_seed_returnhub_demo_creates_expected_records() -> None:
+    """The command should create stable multi-surface users, profiles, and cases."""
+
+    out = StringIO()
+
+    call_command("seed_returnhub_demo", stdout=out)
+
+    user_model = get_user_model()
+    assert Group.objects.filter(name__in=["admin", "ops", "customer", "merchant"]).count() == 4
+    assert (
+        user_model.objects.filter(
+            username__in=[
+                "admin.demo",
+                "ops.demo",
+                "customer.one",
+                "customer.two",
+                "merchant.one",
+                "merchant.two",
+            ]
+        ).count()
+        == 6
+    )
+    assert CustomerProfile.objects.filter(external_reference="CUS-DEMO-0001").exists()
+    assert CustomerProfile.objects.filter(external_reference="CUS-DEMO-0002").exists()
+    assert MerchantProfile.objects.filter(merchant_code="MER-DEMO-0001").exists()
+    assert MerchantProfile.objects.filter(merchant_code="MER-DEMO-0002").exists()
+    assert ReturnCase.objects.filter(order_reference__startswith="RH-").count() == 32
+    assert "ReturnHub demo seed complete." in out.getvalue()
+    assert "Customer users: customer.one, customer.two" in out.getvalue()
+    assert "Merchant users: merchant.one, merchant.two" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_seed_returnhub_demo_is_idempotent() -> None:
+    """Running the command twice should keep deterministic demo counts stable."""
+
+    call_command("seed_returnhub_demo")
+    call_command("seed_returnhub_demo")
+
+    assert CustomerProfile.objects.filter(
+        external_reference__in=["CUS-DEMO-0001", "CUS-DEMO-0002"]
+    ).count() == 2
+    assert MerchantProfile.objects.filter(
+        merchant_code__in=["MER-DEMO-0001", "MER-DEMO-0002"]
+    ).count() == 2
+    assert ReturnCase.objects.filter(order_reference__startswith="RH-").count() == 32
+
+
+@pytest.mark.django_db
+def test_seed_returnhub_demo_reconciles_conflicting_profile_identifiers() -> None:
+    """The command should recover when demo identifiers are already attached elsewhere."""
+
+    user_model = get_user_model()
+
+    customer_two_user = user_model.objects.create_user(
+        username="customer.two",
+        email="customer.two@example.com",
+        password="pass-12345",
+    )
+    CustomerProfile.objects.create(
+        user=customer_two_user,
+        external_reference="CUS-LEGACY-0002",
+        display_name="Legacy Customer Two",
+    )
+
+    legacy_customer_user = user_model.objects.create_user(
+        username="legacy.customer",
+        email="legacy.customer@example.com",
+        password="pass-12345",
+    )
+    CustomerProfile.objects.create(
+        user=legacy_customer_user,
+        external_reference="CUS-DEMO-0002",
+        display_name="Legacy Customer",
+    )
+
+    merchant_one_user = user_model.objects.create_user(
+        username="merchant.one",
+        email="merchant.one@example.com",
+        password="pass-12345",
+    )
+    MerchantProfile.objects.create(
+        user=merchant_one_user,
+        merchant_code="MER-LEGACY-0001",
+        display_name="Legacy Merchant One",
+        support_email="legacy.merchant.one@example.com",
+    )
+
+    legacy_merchant_user = user_model.objects.create_user(
+        username="legacy.merchant",
+        email="legacy.merchant@example.com",
+        password="pass-12345",
+    )
+    CustomerProfile.objects.create(
+        user=user_model.objects.create_user(
+            username="legacy.customer.two",
+            email="legacy.customer.two@example.com",
+            password="pass-12345",
+        ),
+        external_reference="CUS-LEGACY-0003",
+        display_name="Legacy Customer Two",
+    )
+    MerchantProfile.objects.create(
+        user=legacy_merchant_user,
+        merchant_code="MER-DEMO-0001",
+        display_name="Legacy Merchant",
+        support_email="legacy.merchant@example.com",
+    )
+
+    call_command("seed_returnhub_demo")
+
+    canonical_customer = CustomerProfile.objects.get(external_reference="CUS-DEMO-0002")
+    canonical_merchant = MerchantProfile.objects.get(merchant_code="MER-DEMO-0001")
+
+    assert canonical_customer.user.username == "customer.two"
+    assert canonical_merchant.user.username == "merchant.one"
+    assert CustomerProfile.objects.filter(external_reference__startswith="legacy-cus-").exists()
+    assert MerchantProfile.objects.filter(merchant_code__startswith="legacy-mer-").exists()

--- a/tests/test_seed_returnhub_demo_command.py
+++ b/tests/test_seed_returnhub_demo_command.py
@@ -53,12 +53,16 @@ def test_seed_returnhub_demo_is_idempotent() -> None:
     call_command("seed_returnhub_demo")
     call_command("seed_returnhub_demo")
 
-    assert CustomerProfile.objects.filter(
-        external_reference__in=["CUS-DEMO-0001", "CUS-DEMO-0002"]
-    ).count() == 2
-    assert MerchantProfile.objects.filter(
-        merchant_code__in=["MER-DEMO-0001", "MER-DEMO-0002"]
-    ).count() == 2
+    assert (
+        CustomerProfile.objects.filter(
+            external_reference__in=["CUS-DEMO-0001", "CUS-DEMO-0002"]
+        ).count()
+        == 2
+    )
+    assert (
+        MerchantProfile.objects.filter(merchant_code__in=["MER-DEMO-0001", "MER-DEMO-0002"]).count()
+        == 2
+    )
     assert ReturnCase.objects.filter(order_reference__startswith="RH-").count() == 32
 
 


### PR DESCRIPTION
**Summary**
Adds a deterministic multi-surface demo seed command for ReturnHub that provisions stable users, profiles, and paginated return-case data across admin, ops, customer, and merchant surfaces.

**Changes**
- added a new `seed_returnhub_demo` management command under `returns/management/commands/`
- provisioned deterministic demo users for admin, ops, two customers, and two merchants
- attached each demo user to the correct role group using the live `accounts.constants` mappings
- created or updated customer and merchant profiles using the project’s real profile models and fields
- added conflict-safe profile reconciliation for unique `external_reference`, `merchant_code`, and one-to-one user ownership constraints
- seeded deterministic return cases across two customer/merchant pairings to support page 1 and page 2 verification flows
- aligned seeded case data with the live `ReturnCase` model, including valid status, priority, order reference, delivery date, and order value fields
- added package docstrings for `returns.management` and `returns.management.commands`
- formatted the command to satisfy current Black and Ruff checks

**Why**
The project needed a repeatable demo bootstrap for Sprint 6 multi-surface verification that reflects the live ReturnHub data model rather than the stale `apps.*` structure. A deterministic seed command makes manual testing and runbook-driven validation predictable across customer, merchant, ops, and admin surfaces, while also avoiding failures caused by existing profile uniqueness collisions in reused development databases.

**Validation**
- `docker compose exec web python manage.py seed_returnhub_demo`
- `docker compose exec web python -m black returns/management/commands/seed_returnhub_demo.py --check`

**Result**
- the demo seed command now runs successfully end to end
- deterministic demo users are created for all four surfaces
- deterministic customer and merchant profiles are reconciled safely across reruns
- paginated demo case data is available for multi-surface portal verification
- the command now passes current formatting checks

**Notes**
- the command was aligned to the repo’s real `accounts.*` and `returns.*` module layout, not the stale `apps.*` structure
- profile reconciliation intentionally handles both business-key collisions and one-to-one user ownership collisions
- the seeded demo accounts include `customer.one`, `customer.two`, `merchant.one`, `merchant.two`, `ops.demo`, and `admin.demo`