### PR TITLE
Feat/test forbidden rendering and seed idempotency

### DIFF
--- a/tests/test_forbidden_template.py
+++ b/tests/test_forbidden_template.py
@@ -1,0 +1,24 @@
+# path: tests/test_forbidden_template.py
+"""Integration tests for shared forbidden page rendering."""
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from apps.accounts.constants import GROUP_NAMES, ROLE_CUSTOMER
+
+pytestmark = pytest.mark.django_db
+
+
+def test_wrong_role_renders_shared_403_page(client, django_user_model):
+    """Authenticated wrong-role access should render the shared forbidden template."""
+    group, _ = Group.objects.get_or_create(name=GROUP_NAMES[ROLE_CUSTOMER])
+    user = django_user_model.objects.create_user("customer.nav", "customer.nav@example.com", "pass-12345")
+    user.groups.add(group)
+
+    client.force_login(user)
+    response = client.get(reverse("accounts:console_ops"))
+
+    assert response.status_code == 403
+    assert b"You do not have access to this surface" in response.content
+    assert b"Customer portal" in response.content

--- a/tests/test_forbidden_template.py
+++ b/tests/test_forbidden_template.py
@@ -1,24 +1,31 @@
-# path: tests/test_forbidden_template.py
 """Integration tests for shared forbidden page rendering."""
+
+from __future__ import annotations
 
 import pytest
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from apps.accounts.constants import GROUP_NAMES, ROLE_CUSTOMER
+from accounts.constants import GROUP_NAMES, ROLE_CUSTOMER
 
 pytestmark = pytest.mark.django_db
 
 
 def test_wrong_role_renders_shared_403_page(client, django_user_model):
     """Authenticated wrong-role access should render the shared forbidden template."""
+
     group, _ = Group.objects.get_or_create(name=GROUP_NAMES[ROLE_CUSTOMER])
-    user = django_user_model.objects.create_user("customer.nav", "customer.nav@example.com", "pass-12345")
+    user = django_user_model.objects.create_user(
+        "customer.nav",
+        "customer.nav@example.com",
+        "pass-12345",
+    )
     user.groups.add(group)
 
     client.force_login(user)
     response = client.get(reverse("accounts:console_ops"))
 
     assert response.status_code == 403
-    assert b"You do not have access to this surface" in response.content
-    assert b"Customer portal" in response.content
+    assert b"403 Forbidden" in response.content
+    assert b"This surface is outside your current access level." in response.content
+    assert b"Go to sign in" in response.content

--- a/tests/test_seed_returnhub_demo.py
+++ b/tests/test_seed_returnhub_demo.py
@@ -1,16 +1,19 @@
-# path: tests/test_seed_returnhub_demo.py
 """Integration tests for the deterministic demo seed command."""
+
+from __future__ import annotations
 
 import pytest
 from django.core.management import call_command
 
-from apps.returns.models import CustomerProfile, MerchantProfile, ReturnCase
+from accounts.models import CustomerProfile, MerchantProfile
+from returns.models import ReturnCase
 
 pytestmark = pytest.mark.django_db
 
 
 def test_seed_returnhub_demo_is_idempotent():
     """Running the seed command twice should keep stable totals."""
+
     call_command("seed_returnhub_demo")
     first_case_count = ReturnCase.objects.count()
     first_customer_count = CustomerProfile.objects.count()
@@ -26,6 +29,7 @@ def test_seed_returnhub_demo_is_idempotent():
 
 def test_seed_returnhub_demo_creates_page_two_coverage():
     """Seeded data should provide enough cases for page 2 in customer and merchant portals."""
+
     call_command("seed_returnhub_demo")
 
     customer_one_cases = ReturnCase.objects.filter(customer__user__username="customer.one").count()
@@ -33,3 +37,5 @@ def test_seed_returnhub_demo_creates_page_two_coverage():
 
     assert customer_one_cases == 16
     assert merchant_one_cases == 16
+    assert ReturnCase.objects.filter(customer__user__username="customer.two").count() == 16
+    assert ReturnCase.objects.filter(merchant__user__username="merchant.two").count() == 16

--- a/tests/test_seed_returnhub_demo.py
+++ b/tests/test_seed_returnhub_demo.py
@@ -1,0 +1,35 @@
+# path: tests/test_seed_returnhub_demo.py
+"""Integration tests for the deterministic demo seed command."""
+
+import pytest
+from django.core.management import call_command
+
+from apps.returns.models import CustomerProfile, MerchantProfile, ReturnCase
+
+pytestmark = pytest.mark.django_db
+
+
+def test_seed_returnhub_demo_is_idempotent():
+    """Running the seed command twice should keep stable totals."""
+    call_command("seed_returnhub_demo")
+    first_case_count = ReturnCase.objects.count()
+    first_customer_count = CustomerProfile.objects.count()
+    first_merchant_count = MerchantProfile.objects.count()
+
+    call_command("seed_returnhub_demo")
+
+    assert first_case_count == 32
+    assert ReturnCase.objects.count() == 32
+    assert CustomerProfile.objects.count() == first_customer_count == 2
+    assert MerchantProfile.objects.count() == first_merchant_count == 2
+
+
+def test_seed_returnhub_demo_creates_page_two_coverage():
+    """Seeded data should provide enough cases for page 2 in customer and merchant portals."""
+    call_command("seed_returnhub_demo")
+
+    customer_one_cases = ReturnCase.objects.filter(customer__user__username="customer.one").count()
+    merchant_one_cases = ReturnCase.objects.filter(merchant__user__username="merchant.one").count()
+
+    assert customer_one_cases == 16
+    assert merchant_one_cases == 16


### PR DESCRIPTION
**Summary**
Adds integration coverage for shared forbidden-page rendering and deterministic demo-seed behavior, aligned with the live ReturnHub project structure and current multi-surface contracts.

**Changes**
- added integration coverage for shared forbidden-page rendering when an authenticated user hits a surface they are not allowed to access
- aligned forbidden-page assertions with the current branded 403 template copy and recovery actions
- added integration coverage for `seed_returnhub_demo` idempotency
- added integration coverage to confirm the deterministic demo seed creates enough cases for page 2 in both customer and merchant portals
- aligned the new tests to the repo’s live `accounts.*` and `returns.*` module layout
- removed stale `apps.*` assumptions from the test implementation
- updated the demo-seed expectations to match the current multi-surface seed behavior for `customer.one`, `customer.two`, `merchant.one`, and `merchant.two`

**Why**
The project needed explicit regression coverage for two pieces of shared behavior that matter across surfaces: branded forbidden-page rendering and deterministic multi-surface demo seeding. These tests make sure wrong-role access keeps using the shared 403 experience and that the demo seed remains safe to rerun while still producing predictable pagination-ready data for customer and merchant portal verification.

**Validation**
- `docker compose exec web pytest tests/test_forbidden_template.py -q`
- `docker compose exec web pytest tests/test_seed_returnhub_demo.py -q`

**Result**
- shared forbidden rendering is now covered by an integration-style test
- `seed_returnhub_demo` idempotency is now covered by an integration-style test
- deterministic demo seed pagination coverage for both customer and merchant surfaces is now verified
- the new tests are aligned with the live project structure and current template/seed behavior

**Notes**
- the tests were adapted to the current `accounts.*` / `returns.*` layout rather than the stale `apps.*` structure
- the forbidden-page test now targets the current branded 403 copy, including the shared sign-in recovery action
- the demo-seed test now reflects the live multi-surface seed contract rather than older single-surface assumptions