### PR TITLE
test(smoke): add cross-surface shell smoke coverage

### DIFF
--- a/tests/test_surface_smoke.py
+++ b/tests/test_surface_smoke.py
@@ -1,0 +1,85 @@
+# path: tests/test_surface_smoke.py
+"""Cross-surface smoke tests for the Sprint 6 product shell."""
+
+import pytest
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def seeded_data():
+    """Create deterministic demo data for smoke checks."""
+    call_command("seed_returnhub_demo")
+
+
+def login(client, path, username):
+    """Post credentials to the requested login path."""
+    return client.post(
+        path,
+        {"username": username, "password": "ChangeMe123!"},
+    )
+
+
+def test_admin_can_open_admin_console_and_customer_portal_pages(client, seeded_data):
+    """Admin should reach the admin console and inspect customer page 1 and page 2."""
+    login_response = login(client, "/login/admin/", "admin.demo")
+    assert login_response.status_code == 302
+    assert login_response.headers["Location"] == "/console/admin/"
+
+    console_response = client.get("/console/admin/")
+    customer_page_1 = client.get("/customer/?page=1")
+    customer_page_2 = client.get("/customer/?page=2")
+
+    assert console_response.status_code == 200
+    assert customer_page_1.status_code == 200
+    assert customer_page_2.status_code == 200
+
+
+def test_ops_can_open_console_and_ops_page_one_and_two(client, seeded_data):
+    """Ops should reach the ops console and queue pages 1 and 2."""
+    login_response = login(client, "/login/ops/", "ops.demo")
+    assert login_response.status_code == 302
+    assert login_response.headers["Location"] == "/console/ops/"
+
+    console_response = client.get("/console/ops/")
+    ops_page_1 = client.get("/ops/?page=1")
+    ops_page_2 = client.get("/ops/?page=2")
+
+    assert console_response.status_code == 200
+    assert ops_page_1.status_code == 200
+    assert ops_page_2.status_code == 200
+
+
+def test_customer_can_open_console_and_customer_pages_one_and_two(client, seeded_data):
+    """Customer should reach the customer console and customer list pages 1 and 2."""
+    login_response = login(client, "/login/customer/", "customer.one")
+    assert login_response.status_code == 302
+    assert login_response.headers["Location"] == "/console/customer/"
+
+    console_response = client.get("/console/customer/")
+    customer_page_1 = client.get("/customer/?page=1")
+    customer_page_2 = client.get("/customer/?page=2")
+
+    assert console_response.status_code == 200
+    assert customer_page_1.status_code == 200
+    assert customer_page_2.status_code == 200
+    assert b"Showing 1-15 of 16" in customer_page_1.content
+    assert b"Showing 16-16 of 16" in customer_page_2.content
+
+
+def test_merchant_can_open_console_and_merchant_pages_one_and_two(client, seeded_data):
+    """Merchant should reach the merchant console and merchant list pages 1 and 2."""
+    login_response = login(client, "/login/merchant/", "merchant.one")
+    assert login_response.status_code == 302
+    assert login_response.headers["Location"] == "/console/merchant/"
+
+    console_response = client.get("/console/merchant/")
+    merchant_page_1 = client.get("/merchant/?page=1")
+    merchant_page_2 = client.get("/merchant/?page=2")
+
+    assert console_response.status_code == 200
+    assert merchant_page_1.status_code == 200
+    assert merchant_page_2.status_code == 200
+    assert b"Showing 1-15 of 16" in merchant_page_1.content
+    assert b"Showing 16-16 of 16" in merchant_page_2.content


### PR DESCRIPTION
**Summary**
Adds seeded cross-surface smoke coverage for the ReturnHub shell flows and verifies that each primary surface can authenticate, land on its console, and load the expected page-one/page-two routes.

**Changes**
- added a new smoke test module at `tests/test_surface_smoke.py`
- seeded deterministic demo data with `seed_returnhub_demo` for repeatable multi-surface coverage
- exercised admin login through `/login/admin/` and verified redirect to `/console/admin/`
- exercised ops login through `/login/ops/` and verified redirect to `/console/ops/`
- exercised customer login through `/login/customer/` and verified redirect to `/console/customer/`
- exercised merchant login through `/login/merchant/` and verified redirect to `/console/merchant/`
- verified admin can load the admin console plus customer portal page 1 and page 2
- verified ops can load the ops console plus ops queue page 1 and page 2
- verified customer can load the customer console plus customer portal page 1 and page 2
- verified merchant can load the merchant console plus merchant portal page 1 and page 2
- asserted seeded pagination copy for customer and merchant page-two coverage

**Why**
The repository already has targeted tests for individual surfaces, but it did not have a single seeded smoke path that validates the primary product surfaces together from login through console and paginated route access. This adds a lightweight end-to-end confidence check across admin, ops, customer, and merchant flows using the project’s deterministic demo dataset.

**Validation**
- ran `docker compose exec web pytest tests/test_surface_smoke.py`
- verified all 4 smoke tests passed
- confirmed seeded data resolves expected page-two pagination text for customer and merchant surfaces
- confirmed live login and console routes used by the tests match the repository’s current surface structure

**Result**
- cross-surface shell smoke coverage now exists in one seeded integration test module
- admin, ops, customer, and merchant login-to-console flows are covered together
- customer and merchant page-two smoke coverage is explicitly verified
- the suite now provides a fast regression signal for broken surface routing or seeded shell access paths

**Notes**
- this adds integration smoke coverage rather than changing application behavior
- the tests intentionally use `seed_returnhub_demo` instead of factories to validate the project’s seeded demo experience
- the new module overlaps with more targeted tests by design to provide a single cross-surface regression check