### PR TITLE
refactor(core): consolidate live routing and compatibility layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,29 @@ ReturnHub is organized around a shared domain model and service layer:
 
 - `accounts/` defines customer and merchant profiles
 - `returns/` owns return cases, documents, notes, audit events, risk persistence, workflow services, and ops APIs
-- `api/` exposes compatibility views and serializers for the live returns/document APIs
+- `api/` retains compatibility views and serializers that are not the default live route entry points
 - `analytics/` exposes bounded return metrics for ops and admins
 - `console/` serves authenticated dashboard and ops workflow pages
 - `ui/` serves public pages, the shared case workspace, and branded error pages
 - `ml/` owns feature extraction, scoring, model registry access, training flows, and reason-code generation
-- `common/` provides shared pagination, context processors, and demo-data seeding
+- `common/` provides shared pagination, context processors, and legacy demo-data seeding
+
+## Architecture Note
+
+The default live application entry points are:
+
+- `config/urls.py` for route composition
+- `console/` for authenticated console views
+- `returns/` for workflow routes, services, and the live returns API
+- `ui/` for public pages, shared case-detail pages, and branded error handling
+- `analytics/api/` for bounded analytics endpoints
+
+Compatibility and legacy layers retained in the repository:
+
+- `api/` for compatibility API wiring and serializers that are not mounted as the default live router
+- `core/` for compatibility mirrors used by older tests and imports
+- `common.management.commands.seed_demo_data` for the older single-surface seed dataset
+- `web/` as a reserved compatibility scaffold with no live route ownership
 
 ## Core domain
 
@@ -176,6 +193,14 @@ Demo users created by `seed_returnhub_demo`:
 Shared local password:
 
 - `ChangeMe123!`
+
+Preferred seed command for current manual verification and multi-surface demos:
+
+- `docker compose exec -T web python manage.py seed_returnhub_demo`
+
+Legacy compatibility seed still available for older workflows:
+
+- `docker compose exec -T web python manage.py seed_demo_data`
 
 ## Useful commands
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,4 @@
-"""Compatibility API URL routes mirroring the live returns API structure."""
+"""Compatibility API URL routes not mounted by the default project router."""
 
 from __future__ import annotations
 

--- a/common/management/commands/seed_demo_data.py
+++ b/common/management/commands/seed_demo_data.py
@@ -1,5 +1,5 @@
 # path: common/management/commands/seed_demo_data.py
-"""Seed deterministic demo data for local development and manual testing."""
+"""Seed deterministic legacy demo data for compatibility and manual testing."""
 from datetime import date, datetime, timedelta
 
 from django.contrib.auth import get_user_model
@@ -13,9 +13,9 @@ from returns.models import CaseEvent, ReturnCase
 
 
 class Command(BaseCommand):
-    """Create stable demo users, groups, and return cases."""
+    """Create the legacy single-surface demo dataset."""
 
-    help = "Seed deterministic demo users, groups, and return cases."
+    help = "Seed the legacy single-surface demo users, groups, and return cases."
 
     GROUP_NAMES = ["Admin", "Ops", "Customer", "Merchant"]
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -23,7 +23,6 @@ urlpatterns = [
     ),
     path("ops/", include(("returns.urls.ops", "ops"), namespace="ops")),
     path("console/", include("console.urls")),
-    path("api/", include("api.urls")),
     path("api/analytics/", include("analytics.api.urls")),
     path("api/returns/", include("returns.api.urls")),
     path("admin/", admin.site.urls),

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,5 @@
 # path: core/urls.py
-"""Core URL routes aligned with the live public and console shells."""
+"""Compatibility URL mirrors for the live public and console shells."""
 
 from __future__ import annotations
 

--- a/core/views/console.py
+++ b/core/views/console.py
@@ -1,65 +1,21 @@
 # path: core/views/console.py
-"""Role-specific console views aligned with the live console shell."""
+"""Compatibility shim for the live console views."""
 
 from __future__ import annotations
 
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.views.generic import TemplateView
 
-from common.pagination import paginate_queryset
-from returns.models import ReturnCase
-from returns.services.queue import build_queue_queryset, get_queue_summary, parse_queue_filters
-
-CUSTOMER_TIMELINE_ITEMS = (
-    {
-        "title": "See your own cases",
-        "body": (
-            "Keep customer-linked returns visible in one place while later "
-            "releases add deeper case actions."
-        ),
-    },
-    {
-        "title": "Track progress clearly",
-        "body": (
-            "Status, messages, and recent activity stay inside the same " "branded console shell."
-        ),
-    },
-    {
-        "title": "Prepare for evidence flows",
-        "body": (
-            "This layout leaves room for uploads, document review, and richer "
-            "case detail without changing the frame."
-        ),
-    },
-)
-
-MERCHANT_TIMELINE_ITEMS = (
-    {
-        "title": "Review linked cases",
-        "body": (
-            "Keep merchant-linked returns grouped together in the same "
-            "operational frame used across ReturnHub."
-        ),
-    },
-    {
-        "title": "Stay in shared workflow context",
-        "body": (
-            "Case summaries remain visible while later product updates add merchant "
-            "responses and supporting documents."
-        ),
-    },
-    {
-        "title": "Grow into response handling",
-        "body": (
-            "The shared layout is ready for merchant-side actions without "
-            "duplicating the surrounding shell."
-        ),
-    },
+from accounts.mixins import is_admin_user, user_in_group
+from console.views import (
+    AdminConsoleView,
+    CustomerConsoleView,
+    MerchantConsoleView,
+    OpsConsoleView,
 )
 
 
 class RoleRequiredMixin(LoginRequiredMixin, UserPassesTestMixin):
-    """Require the current user to belong to one of the configured groups."""
+    """Compatibility role guard retained for tests and older imports."""
 
     allowed_groups: tuple[str, ...] = ()
     raise_exception = True
@@ -67,102 +23,15 @@ class RoleRequiredMixin(LoginRequiredMixin, UserPassesTestMixin):
     def test_func(self) -> bool:
         """Validate group membership for the current request."""
         user = self.request.user
-        return user.is_superuser or any(
-            user.groups.filter(name__iexact=group_name).exists()
-            for group_name in self.allowed_groups
+        return is_admin_user(user) or any(
+            user_in_group(user, group_name) for group_name in self.allowed_groups
         )
 
 
-class AdminConsoleView(RoleRequiredMixin, TemplateView):
-    """In-product admin console shell."""
-
-    template_name = "console/admin_dashboard.html"
-    allowed_groups = ("Admin",)
-
-    def get_context_data(self, **kwargs):
-        """Build the admin dashboard context."""
-        context = super().get_context_data(**kwargs)
-        context["page_title"] = "Admin Console"
-        context["total_cases"] = ReturnCase.objects.count()
-        return context
-
-
-class OpsConsoleView(RoleRequiredMixin, TemplateView):
-    """Ops console shell for the server-rendered return queue."""
-
-    template_name = "console/ops_dashboard.html"
-    allowed_groups = ("Ops", "Admin")
-
-    def get_context_data(self, **kwargs):
-        """Build the ops queue context."""
-        context = super().get_context_data(**kwargs)
-        queue_filters = parse_queue_filters(self.request.GET)
-        queryset = build_queue_queryset(queue_filters)
-        pagination = paginate_queryset(queryset, self.request.GET.get("page"))
-        context["page_title"] = "Ops Console"
-        context["queue_filters"] = queue_filters
-        context["queue_summary"] = get_queue_summary(queryset)
-        context["pagination"] = pagination
-        return context
-
-
-class CustomerConsoleView(RoleRequiredMixin, TemplateView):
-    """Customer console shell."""
-
-    template_name = "console/customer_dashboard.html"
-    allowed_groups = ("Customer", "Admin")
-
-    def get_context_data(self, **kwargs):
-        """Build the customer dashboard context."""
-        context = super().get_context_data(**kwargs)
-        queryset = ReturnCase.objects.none()
-        if hasattr(self.request.user, "customer_profile"):
-            queryset = ReturnCase.objects.filter(
-                customer=self.request.user.customer_profile
-            ).order_by("-created_at")
-        context["page_title"] = "Customer Console"
-        context["recent_cases"] = queryset[:5]
-        context["customer_timeline_items"] = CUSTOMER_TIMELINE_ITEMS
-        context["customer_trust_items"] = (
-            "Own-case visibility",
-            "Shared case history",
-            "Role-aware access",
-        )
-        context["customer_visual_case_meta_items"] = ("item_category", "delivery_date")
-        context["customer_recent_case_meta_items"] = (
-            "item_category",
-            "return_reason",
-            "delivery_date",
-        )
-        return context
-
-
-class MerchantConsoleView(RoleRequiredMixin, TemplateView):
-    """Merchant console shell."""
-
-    template_name = "console/merchant_dashboard.html"
-    allowed_groups = ("Merchant", "Admin")
-
-    def get_context_data(self, **kwargs):
-        """Build the merchant dashboard context."""
-        context = super().get_context_data(**kwargs)
-        queryset = ReturnCase.objects.none()
-        if hasattr(self.request.user, "merchant_profile"):
-            queryset = ReturnCase.objects.filter(
-                merchant=self.request.user.merchant_profile
-            ).order_by("-created_at")
-        context["page_title"] = "Merchant Console"
-        context["recent_cases"] = queryset[:5]
-        context["merchant_timeline_items"] = MERCHANT_TIMELINE_ITEMS
-        context["merchant_trust_items"] = (
-            "Merchant-linked cases",
-            "Shared workflow context",
-            "Future response handling",
-        )
-        context["merchant_visual_case_meta_items"] = ("item_category", "order_value")
-        context["merchant_recent_case_meta_items"] = (
-            "item_category",
-            "return_reason",
-            "order_value",
-        )
-        return context
+__all__ = [
+    "AdminConsoleView",
+    "CustomerConsoleView",
+    "MerchantConsoleView",
+    "OpsConsoleView",
+    "RoleRequiredMixin",
+]

--- a/returns/management/commands/seed_returnhub_demo.py
+++ b/returns/management/commands/seed_returnhub_demo.py
@@ -23,9 +23,9 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    """Create stable users, profiles, and cases for the ReturnHub multi-surface demo."""
+    """Create the preferred users, profiles, and cases for the ReturnHub multi-surface demo."""
 
-    help = "Seed deterministic users and paginated return cases for the ReturnHub demo."
+    help = "Seed the preferred deterministic multi-surface demo users and paginated return cases."
 
     def handle(self, *args, **options):
         """Create demo users, groups, profiles, and enough cases for page 1 and page 2."""

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,1 +1,1 @@
-"""Web application package."""
+"""Reserved compatibility scaffold; live web routes are owned by ui/, console/, and returns/."""

--- a/web/forms/__init__.py
+++ b/web/forms/__init__.py
@@ -1,1 +1,1 @@
-"""Form package for web-facing views."""
+"""Reserved compatibility scaffold for web-facing forms."""

--- a/web/views/__init__.py
+++ b/web/views/__init__.py
@@ -1,1 +1,1 @@
-"""View package for web-facing routes."""
+"""Reserved compatibility scaffold for web-facing views."""


### PR DESCRIPTION
**Summary**
Consolidates live route ownership, removes duplicate implementation drift in the console layer, and makes the repository’s compatibility and legacy layers explicit in both code and documentation.

**Changes**
- removed the duplicate live `api.urls` mount from `config/urls.py`
- kept `returns.api.urls` as the canonical live returns API router under `/api/returns/`
- kept `analytics.api.urls` as the canonical live analytics router under `/api/analytics/`
- left `api/urls.py` in place as a compatibility layer instead of a default live route entry point
- replaced the parallel implementation in `core/views/console.py` with a compatibility shim over `console.views`
- preserved `RoleRequiredMixin` in `core/views/console.py` for older tests and imports
- clarified `core/urls.py` as a compatibility URL mirror rather than a primary routing layer
- marked `seed_returnhub_demo` as the preferred multi-surface demo seed command
- marked `seed_demo_data` as the legacy single-surface compatibility seed command
- documented the empty `web/` package as a reserved compatibility scaffold
- added a README architecture note separating live application entry points from compatibility and legacy layers
- clarified README guidance for preferred versus legacy seed commands

**Why**
The project had accumulated multiple overlapping ownership paths:
- duplicate live API routing through both `api.urls` and `returns.api.urls`
- a second console implementation in `core/views/console.py` that could drift from the live `console/views.py`
- two different demo seed commands without a clear preferred/default story
- placeholder compatibility packages that looked active without explanation

This refactor reduces ambiguity in the live application path while preserving compatibility where tests or older imports still rely on it.

**Validation**
- ran focused routing, console, seed, and compatibility tests:
  `docker compose exec web pytest -q tests/test_core_console_views.py tests/test_core_urls.py tests/test_console_views.py tests/test_seed_demo_data.py tests/test_seed_demo_data_command.py tests/test_seed_returnhub_demo_command.py tests/test_surface_smoke.py tests/test_public_views.py tests/test_surface_login_views.py tests/test_console_access.py tests/test_forbidden_template.py tests/test_return_api_views.py tests/test_api_compat_documents.py`
- result: `60 passed in 6.38s`
- ran focused lint checks on the refactored files:
  `docker compose exec web python -m ruff check config/urls.py core/views/console.py core/urls.py api/urls.py common/management/commands/seed_demo_data.py returns/management/commands/seed_returnhub_demo.py`
- result: `All checks passed!`

**Result**
- live routing ownership is clearer and less error-prone
- console behavior now has one real implementation instead of two drifting copies
- seed command intent is explicit for both current multi-surface demos and legacy compatibility flows
- repository structure is easier to understand for future maintenance

**Notes**
- this change is a structural refactor and documentation cleanup; it does not change the intended external behavior of the live product surfaces
- `api/`, `core/`, and `web/` remain present as compatibility or reserved layers, but they are no longer implied to be the primary live application path