### PR TITLE
refactor(config): mount health check directly in root urls

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,10 +1,13 @@
-# path: config/urls.py
-"""Project URL configuration for ReturnHub."""
+"""Top-level URL configuration for ReturnHub."""
+
+from __future__ import annotations
 
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+
+from core.api.views import HealthCheckView
 
 handler403 = "ui.error_views.error_403"
 handler404 = "ui.error_views.error_404"
@@ -23,7 +26,7 @@ urlpatterns = [
     ),
     path("ops/", include(("returns.urls.ops", "ops"), namespace="ops")),
     path("console/", include("console.urls")),
-    path("api/", include("core.api.urls")),
+    path("api/health/", HealthCheckView.as_view(), name="api-health"),
     path("api/analytics/", include("analytics.api.urls")),
     path("api/returns/", include("returns.api.urls")),
     path("admin/", admin.site.urls),

--- a/tests/test_core_urls.py
+++ b/tests/test_core_urls.py
@@ -33,8 +33,8 @@ def test_ops_namespace_routes_to_real_case_detail_page() -> None:
 def test_api_health_route_resolves_to_core_health_check() -> None:
     """The root router should expose the operational health endpoint."""
 
-    assert reverse("core_api:health") == "/api/health/"
-    assert resolve("/api/health/").view_name == "core_api:health"
+    assert reverse("api-health") == "/api/health/"
+    assert resolve("/api/health/").view_name == "api-health"
 
 
 def test_config_urls_appends_media_patterns_when_debug(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Moves the health check route registration into the root URL configuration so the readiness endpoint is declared explicitly in the main router.

## Changes
- import `HealthCheckView` directly in `config/urls.py`
- register `/api/health/` as a top-level named route: `api-health`
- preserve the existing project URL structure for accounts, UI, console, returns, analytics, admin, and debug media routing
- update URL tests to assert the direct root-level health route

## Behavior
- `GET /api/health/` remains publicly accessible
- the readiness endpoint is declared directly in the root router instead of being discovered through a nested include
- the health probe still returns `200` when healthy and `503` when degraded

## Why
- keeps the probe path explicit and easy to discover in the main project router
- aligns the routing with the intended deployment-facing behavior for readiness checks
- avoids depending on an extra include layer for a single operational endpoint

## Validation
- `docker compose exec web pytest tests/test_core_urls.py tests/test_core_health_api.py -q`

## Result
- focused URL and health endpoint tests passed: `11 passed`

## Notes
- the merge kept the repo’s real module paths such as `core.api.views`, `accounts.urls`, `ui.urls`, `console.urls`, `returns.urls.*`, and `analytics.api.urls`
- the `apps.*` paths from the proposed snippet were not used because they do not exist in this project