### PR TITLE
Feat/test readiness contract

### DIFF
--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,4 +1,3 @@
-# path: tests/test_health_api.py
 """Integration tests for the readiness endpoint."""
 
 from __future__ import annotations
@@ -10,7 +9,7 @@ from django.urls import reverse
 @pytest.mark.django_db
 def test_health_endpoint_returns_ok_when_database_is_available(client) -> None:
     """The readiness endpoint should return a 200 response when checks pass."""
-    response = client.get(reverse("api-health"))
+    response = client.get(reverse("core_api:health"))
 
     assert response.status_code == 200
     payload = response.json()
@@ -24,7 +23,7 @@ def test_health_endpoint_returns_ok_when_database_is_available(client) -> None:
 def test_health_endpoint_returns_503_when_required_check_fails(client, monkeypatch) -> None:
     """A degraded dependency should produce a 503 response and stable payload shape."""
     monkeypatch.setattr(
-        "apps.core.api.get_readiness_payload",
+        "core.api.views.get_readiness_payload",
         lambda: {
             "status": "degraded",
             "service": "returnhub",
@@ -34,7 +33,7 @@ def test_health_endpoint_returns_503_when_required_check_fails(client, monkeypat
         },
     )
 
-    response = client.get(reverse("api-health"))
+    response = client.get(reverse("core_api:health"))
 
     assert response.status_code == 503
     payload = response.json()

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,0 +1,43 @@
+# path: tests/test_health_api.py
+"""Integration tests for the readiness endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_health_endpoint_returns_ok_when_database_is_available(client) -> None:
+    """The readiness endpoint should return a 200 response when checks pass."""
+    response = client.get(reverse("api-health"))
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["status"] == "ok"
+    assert payload["service"] == "returnhub"
+    assert payload["checks"]["database"] == "ok"
+    assert "timestamp" in payload
+
+
+def test_health_endpoint_returns_503_when_required_check_fails(client, monkeypatch) -> None:
+    """A degraded dependency should produce a 503 response and stable payload shape."""
+    monkeypatch.setattr(
+        "apps.core.api.get_readiness_payload",
+        lambda: {
+            "status": "degraded",
+            "service": "returnhub",
+            "release": "test",
+            "timestamp": "2026-03-09T09:00:00+00:00",
+            "checks": {"database": "unavailable"},
+        },
+    )
+
+    response = client.get(reverse("api-health"))
+
+    assert response.status_code == 503
+    payload = response.json()
+
+    assert payload["status"] == "degraded"
+    assert payload["checks"]["database"] == "unavailable"


### PR DESCRIPTION
## Summary
Adds focused test coverage for the readiness contract exposed by `/api/health/`.

## Changes
- add integration coverage in `tests/test_health_api.py` for the public health endpoint
- verify the healthy path returns `200 OK` with the expected readiness payload fields
- verify the degraded path returns `503 Service Unavailable` with a stable payload shape
- align the tests with the actual project routing and view import paths

## Behavior
- `GET /api/health/` is exercised through the real URL configuration
- healthy checks return `200` with `status=ok` and `checks.database=ok`
- degraded checks return `503` with `status=degraded` and `checks.database=unavailable`
- the response contract remains stable for monitoring and deployment tooling

## Why
- protects the readiness endpoint from regressions in route wiring and response shape
- ensures both operational states are covered explicitly
- improves confidence in the deployment-facing contract reported by the health probe

## Validation
- `docker compose exec web pytest tests/test_health_api.py -q`

## Result
- focused readiness endpoint integration tests passed: `2 passed`

## Notes
- the tests were updated to use the repo’s real route namespace, `core_api:health`
- the degraded-path test patches `core.api.views.get_readiness_payload`, which matches the actual view implementation