### PR TITLE
Feat/add production settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # Copy this file to `.env` once, then edit `.env` directly.
 # Do not re-copy this file over an existing `.env`, or you will overwrite
 # local values such as RELEASE_VERSION and other environment-specific settings.
+# Optional: set DJANGO_SETTINGS_MODULE=config.settings.production for a
+# production-style process. The repo defaults to config.settings.dev when this
+# variable is unset.
 DJANGO_SECRET_KEY=change-me-for-local-development
 DJANGO_DEBUG=1
 RELEASE_VERSION=dev

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# path: .env.example
+# Local environment template for first-time setup only.
+# Copy this file to `.env` once, then edit `.env` directly.
+# Do not re-copy this file over an existing `.env`, or you will overwrite
+# local values such as RELEASE_VERSION and other environment-specific settings.
 DJANGO_SECRET_KEY=change-me-for-local-development
 DJANGO_DEBUG=1
+RELEASE_VERSION=dev
 DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
 POSTGRES_DB=returnhub
 POSTGRES_USER=returnhub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     env:
       DJANGO_SETTINGS_MODULE: config.settings.test
       DJANGO_SECRET_KEY: ci-secret-key
+      RELEASE_VERSION: ci
       DJANGO_ALLOWED_HOSTS: localhost,127.0.0.1
       POSTGRES_DB: returnhub
       POSTGRES_USER: returnhub

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ docker compose exec -T web python manage.py migrate --noinput
 docker compose exec -T web python manage.py seed_returnhub_demo
 ```
 
+Local health-check release identifier:
+
+- set `RELEASE_VERSION` in `.env` to control the value returned by `/api/health/`
+- examples: `RELEASE_VERSION=dev`, `RELEASE_VERSION=staging-2026-04-21`, `RELEASE_VERSION=prod-2026-04-21`
+
 Application URL:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Local health-check release identifier:
 
 - set `RELEASE_VERSION` in `.env` to control the value returned by `/api/health/`
 - examples: `RELEASE_VERSION=dev`, `RELEASE_VERSION=staging-2026-04-21`, `RELEASE_VERSION=prod-2026-04-21`
+- set `DJANGO_SETTINGS_MODULE=config.settings.production` in `.env` to run the app with the production settings module instead of the default `config.settings.dev`
 
 Application URL:
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Local health-check release identifier:
 - set `RELEASE_VERSION` in `.env` to control the value returned by `/api/health/`
 - examples: `RELEASE_VERSION=dev`, `RELEASE_VERSION=staging-2026-04-21`, `RELEASE_VERSION=prod-2026-04-21`
 - set `DJANGO_SETTINGS_MODULE=config.settings.production` in `.env` to run the app with the production settings module instead of the default `config.settings.dev`
+- use [production.env.example](production.env.example) and [docs/deployment.md](docs/deployment.md) for the production deployment path instead of reusing the local `.env.example`
 
 Application URL:
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -38,6 +38,12 @@ Create the local environment file.
 cp .env.example .env
 ```
 
+Set the release identifier returned by `/api/health/` when needed.
+
+- local default: `RELEASE_VERSION=dev`
+- staging example: `RELEASE_VERSION=staging-2026-04-21`
+- production example: `RELEASE_VERSION=prod-2026-04-21`
+
 Start the containers.
 
 ```bash

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -10,6 +10,7 @@ load_dotenv(BASE_DIR / ".env")
 
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "unsafe-dev-key")
 DEBUG = os.getenv("DJANGO_DEBUG", "0") == "1"
+RELEASE_VERSION = os.getenv("RELEASE_VERSION", "dev")
 ALLOWED_HOSTS = [
     host.strip()
     for host in os.getenv(

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,0 +1,39 @@
+# path: config/settings/production.py
+"""Production settings for ReturnHub."""
+
+from __future__ import annotations
+
+from .base import *  # noqa: F401,F403
+from .production_helpers import env_bool, env_int, env_list
+
+DEBUG = False
+
+ALLOWED_HOSTS = env_list("DJANGO_ALLOWED_HOSTS", ["localhost", "127.0.0.1"])
+CSRF_TRUSTED_ORIGINS = env_list("DJANGO_CSRF_TRUSTED_ORIGINS", ["https://localhost"])
+
+STATIC_ROOT = BASE_DIR / "staticfiles"  # noqa: F405
+MEDIA_ROOT = BASE_DIR / "media"  # noqa: F405
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+
+SECURE_SSL_REDIRECT = env_bool("DJANGO_SECURE_SSL_REDIRECT", True)
+SESSION_COOKIE_SECURE = env_bool("DJANGO_SESSION_COOKIE_SECURE", True)
+CSRF_COOKIE_SECURE = env_bool("DJANGO_CSRF_COOKIE_SECURE", True)
+
+SESSION_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_SAMESITE = "Lax"
+
+SECURE_HSTS_SECONDS = env_int("DJANGO_SECURE_HSTS_SECONDS", 31536000)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = env_bool(
+    "DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS",
+    True,
+)
+SECURE_HSTS_PRELOAD = env_bool("DJANGO_SECURE_HSTS_PRELOAD", True)
+
+SECURE_REFERRER_POLICY = "same-origin"
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
+X_FRAME_OPTIONS = "DENY"
+
+RELEASE_VERSION = env_list("RELEASE_VERSION", ["dev"])[0]

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+
 from .base import *  # noqa: F401,F403
 from .production_helpers import env_bool, env_int, env_list
 
@@ -36,4 +38,4 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
 X_FRAME_OPTIONS = "DENY"
 
-RELEASE_VERSION = env_list("RELEASE_VERSION", ["dev"])[0]
+RELEASE_VERSION = os.getenv("RELEASE_VERSION", "dev")

--- a/config/settings/production_helpers.py
+++ b/config/settings/production_helpers.py
@@ -1,0 +1,31 @@
+# path: config/settings/production_helpers.py
+"""Helpers for parsing environment-driven production settings."""
+
+from __future__ import annotations
+
+import os
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    """Return an environment variable parsed as a boolean."""
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def env_int(name: str, default: int) -> int:
+    """Return an environment variable parsed as an integer."""
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return int(raw_value.strip())
+
+
+def env_list(name: str, default: list[str] | None = None) -> list[str]:
+    """Return a comma-separated environment variable parsed into a list."""
+    raw_value = os.getenv(name)
+    if raw_value is None or not raw_value.strip():
+        return default or []
+
+    return [item.strip() for item in raw_value.split(",") if item.strip()]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,61 @@
+# Production Deployment
+
+This repository defaults to `config.settings.dev` when `DJANGO_SETTINGS_MODULE`
+is unset. Production deployment should override that explicitly in the
+deployment platform, not through ad hoc shell exports.
+
+## Required selection
+
+Set this environment variable in the deployment platform:
+
+```text
+DJANGO_SETTINGS_MODULE=config.settings.production
+```
+
+This is the single explicit switch that enables the production settings module.
+
+## Recommended production env template
+
+Use [production.env.example](../production.env.example) as the deployment-facing
+template for production configuration.
+
+Key values:
+
+- `DJANGO_SETTINGS_MODULE=config.settings.production`
+- `DJANGO_SECRET_KEY=<strong secret>`
+- `DJANGO_ALLOWED_HOSTS=<public hostnames>`
+- `DJANGO_CSRF_TRUSTED_ORIGINS=<https origins>`
+- `POSTGRES_*` database connection values
+- `RELEASE_VERSION=<deployment identifier>`
+
+## Verification
+
+After deployment, verify that the process is using the production settings
+module:
+
+```bash
+python manage.py shell -c "from django.conf import settings; print(settings.SETTINGS_MODULE)"
+```
+
+Expected output:
+
+```text
+config.settings.production
+```
+
+Verify the readiness endpoint exposes the deployed release identifier:
+
+```bash
+curl -s https://your-domain.example.com/api/health/ | python -m json.tool
+```
+
+Expected result:
+
+- response contains `"status": "ok"` when the app is healthy
+- response contains `"release": "<your deployed RELEASE_VERSION>"`
+
+## Notes
+
+- Keep `.env.example` for local development only.
+- Do not rely on one-off `export DJANGO_SETTINGS_MODULE=...` commands during deploy.
+- Keep production-only behavior in `config/settings/production.py`.

--- a/production.env.example
+++ b/production.env.example
@@ -1,0 +1,28 @@
+# Production environment template.
+# Use this file as the deployment-facing source of truth for selecting the
+# production settings module. Do not use `.env.example` for production.
+#
+# Copy or translate these values into your deployment platform's env settings.
+# The critical switch is DJANGO_SETTINGS_MODULE=config.settings.production.
+
+DJANGO_SETTINGS_MODULE=config.settings.production
+
+DJANGO_SECRET_KEY=replace-with-a-strong-secret
+DJANGO_ALLOWED_HOSTS=your-domain.example.com
+DJANGO_CSRF_TRUSTED_ORIGINS=https://your-domain.example.com
+
+POSTGRES_DB=returnhub
+POSTGRES_USER=returnhub
+POSTGRES_PASSWORD=replace-with-a-production-password
+POSTGRES_HOST=your-postgres-host
+POSTGRES_PORT=5432
+
+RELEASE_VERSION=prod-2026-04-21
+
+# Optional production overrides.
+DJANGO_SECURE_SSL_REDIRECT=1
+DJANGO_SESSION_COOKIE_SECURE=1
+DJANGO_CSRF_COOKIE_SECURE=1
+DJANGO_SECURE_HSTS_SECONDS=31536000
+DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS=1
+DJANGO_SECURE_HSTS_PRELOAD=1

--- a/tests/test_production_settings.py
+++ b/tests/test_production_settings.py
@@ -1,0 +1,125 @@
+"""Tests for production settings and environment parsing helpers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+from config.settings.production_helpers import env_bool, env_int, env_list
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "default", "expected"),
+    [
+        (None, False, False),
+        (None, True, True),
+        ("1", False, True),
+        ("true", False, True),
+        ("YES", False, True),
+        ("on", False, True),
+        ("0", True, False),
+        ("false", True, False),
+    ],
+)
+def test_env_bool_parses_truthy_falsey_and_default_values(
+    monkeypatch, raw_value: str | None, default: bool, expected: bool
+) -> None:
+    """Boolean helper should support explicit truthy values and fallback defaults."""
+    if raw_value is None:
+        monkeypatch.delenv("BOOL_SETTING", raising=False)
+    else:
+        monkeypatch.setenv("BOOL_SETTING", raw_value)
+
+    assert env_bool("BOOL_SETTING", default) is expected
+
+
+def test_env_int_parses_integer_values_and_defaults(monkeypatch) -> None:
+    """Integer helper should return defaults when unset and parse numeric strings."""
+    monkeypatch.delenv("INT_SETTING", raising=False)
+    assert env_int("INT_SETTING", 7) == 7
+
+    monkeypatch.setenv("INT_SETTING", "42")
+    assert env_int("INT_SETTING", 7) == 42
+
+
+def test_env_list_splits_comma_separated_values_and_handles_defaults(monkeypatch) -> None:
+    """List helper should trim values and preserve the provided default list."""
+    monkeypatch.delenv("LIST_SETTING", raising=False)
+    assert env_list("LIST_SETTING", ["a", "b"]) == ["a", "b"]
+    assert env_list("LIST_SETTING") == []
+
+    monkeypatch.setenv("LIST_SETTING", " alpha, beta ,, gamma ")
+    assert env_list("LIST_SETTING") == ["alpha", "beta", "gamma"]
+
+
+def test_production_settings_apply_env_driven_security_and_release_values(monkeypatch) -> None:
+    """Production settings should expose the expected hardened env-driven values."""
+    monkeypatch.setenv("DJANGO_ALLOWED_HOSTS", "app.example.com,api.example.com")
+    monkeypatch.setenv(
+        "DJANGO_CSRF_TRUSTED_ORIGINS",
+        "https://app.example.com,https://api.example.com",
+    )
+    monkeypatch.setenv("DJANGO_SECURE_SSL_REDIRECT", "false")
+    monkeypatch.setenv("DJANGO_SESSION_COOKIE_SECURE", "0")
+    monkeypatch.setenv("DJANGO_CSRF_COOKIE_SECURE", "1")
+    monkeypatch.setenv("DJANGO_SECURE_HSTS_SECONDS", "86400")
+    monkeypatch.setenv("DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", "0")
+    monkeypatch.setenv("DJANGO_SECURE_HSTS_PRELOAD", "false")
+    monkeypatch.setenv("RELEASE_VERSION", "prod-2026-04-21")
+
+    sys.modules.pop("config.settings.production", None)
+    production_settings = importlib.import_module("config.settings.production")
+
+    assert production_settings.DEBUG is False
+    assert production_settings.ALLOWED_HOSTS == ["app.example.com", "api.example.com"]
+    assert production_settings.CSRF_TRUSTED_ORIGINS == [
+        "https://app.example.com",
+        "https://api.example.com",
+    ]
+    assert production_settings.SECURE_SSL_REDIRECT is False
+    assert production_settings.SESSION_COOKIE_SECURE is False
+    assert production_settings.CSRF_COOKIE_SECURE is True
+    assert production_settings.SESSION_COOKIE_SAMESITE == "Lax"
+    assert production_settings.CSRF_COOKIE_SAMESITE == "Lax"
+    assert production_settings.SECURE_HSTS_SECONDS == 86400
+    assert production_settings.SECURE_HSTS_INCLUDE_SUBDOMAINS is False
+    assert production_settings.SECURE_HSTS_PRELOAD is False
+    assert production_settings.SECURE_PROXY_SSL_HEADER == ("HTTP_X_FORWARDED_PROTO", "https")
+    assert production_settings.USE_X_FORWARDED_HOST is True
+    assert production_settings.SECURE_REFERRER_POLICY == "same-origin"
+    assert production_settings.SECURE_CONTENT_TYPE_NOSNIFF is True
+    assert production_settings.SECURE_CROSS_ORIGIN_OPENER_POLICY == "same-origin"
+    assert production_settings.X_FRAME_OPTIONS == "DENY"
+    assert production_settings.RELEASE_VERSION == "prod-2026-04-21"
+
+
+def test_production_settings_fall_back_to_repo_defaults(monkeypatch) -> None:
+    """Production settings should retain documented defaults when env vars are absent."""
+    for name in [
+        "DJANGO_ALLOWED_HOSTS",
+        "DJANGO_CSRF_TRUSTED_ORIGINS",
+        "DJANGO_SECURE_SSL_REDIRECT",
+        "DJANGO_SESSION_COOKIE_SECURE",
+        "DJANGO_CSRF_COOKIE_SECURE",
+        "DJANGO_SECURE_HSTS_SECONDS",
+        "DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS",
+        "DJANGO_SECURE_HSTS_PRELOAD",
+        "RELEASE_VERSION",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+    sys.modules.pop("config.settings.production", None)
+    production_settings = importlib.import_module("config.settings.production")
+
+    assert production_settings.ALLOWED_HOSTS == ["localhost", "127.0.0.1"]
+    assert production_settings.CSRF_TRUSTED_ORIGINS == ["https://localhost"]
+    assert production_settings.SECURE_SSL_REDIRECT is True
+    assert production_settings.SESSION_COOKIE_SECURE is True
+    assert production_settings.CSRF_COOKIE_SECURE is True
+    assert production_settings.SECURE_HSTS_SECONDS == 31536000
+    assert production_settings.SECURE_HSTS_INCLUDE_SUBDOMAINS is True
+    assert production_settings.SECURE_HSTS_PRELOAD is True
+    assert production_settings.RELEASE_VERSION == "dev"

--- a/tests/test_production_settings.py
+++ b/tests/test_production_settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import os
 import sys
 
 import pytest


### PR DESCRIPTION
## Summary
Adds a dedicated production settings module and deployment-facing configuration path so production behavior is centralized and selected explicitly through environment configuration.

## Changes
- add `config/settings/production.py` with production-specific security, proxy, host, and cookie settings
- add `config/settings/production_helpers.py` for parsing boolean, integer, and list environment values
- align `RELEASE_VERSION` in production settings with the repo’s existing string-based env convention
- add `production.env.example` as the production-facing environment template
- add `docs/deployment.md` to document the production startup path and verification steps
- update `.env.example` and `README.md` to distinguish local and production configuration flows

## Behavior
- the app still defaults to `config.settings.dev` when `DJANGO_SETTINGS_MODULE` is unset
- production is activated explicitly by setting `DJANGO_SETTINGS_MODULE=config.settings.production`
- production settings now centralize security-related behavior instead of relying on ad hoc environment overrides
- `/api/health/` continues to expose the environment-specific `RELEASE_VERSION`

## Why
- makes production startup explicit and repeatable
- keeps local development defaults intact while providing a first-class production configuration path
- reduces the risk of deploying with dev settings or undocumented one-off overrides
- gives deployment environments a concrete template and verification flow

## Validation
- verified the settings package structure and startup defaults against the repo
- confirmed the production activation path is documented through `production.env.example` and `docs/deployment.md`

## Result
- production-only behavior is now centralized in a dedicated settings module
- the deployment platform has a single explicit switch for selecting production settings
- local and production env templates are separated to avoid accidental reuse

## Notes
- deployment still requires the platform to set `DJANGO_SETTINGS_MODULE=config.settings.production`
- `manage.py`, `config/wsgi.py`, and `config/asgi.py` intentionally keep `config.settings.dev` as the default fallback for local development