### PR TITLE
Feat/add environment parsing helpers

### DIFF
--- a/tests/test_production_helpers.py
+++ b/tests/test_production_helpers.py
@@ -1,0 +1,38 @@
+# path: tests/test_production_helpers.py
+"""Unit tests for production environment parsing helpers."""
+
+from __future__ import annotations
+
+from config.settings.production_helpers import env_bool, env_int, env_list
+
+
+def test_env_bool_parses_truthy_values(monkeypatch) -> None:
+    """Truthy string values should evaluate to True."""
+    monkeypatch.setenv("TEST_BOOL", "true")
+
+    assert env_bool("TEST_BOOL") is True
+
+
+def test_env_bool_returns_default_when_missing(monkeypatch) -> None:
+    """Missing values should fall back to the provided default."""
+    monkeypatch.delenv("TEST_BOOL", raising=False)
+
+    assert env_bool("TEST_BOOL", default=True) is True
+
+
+def test_env_int_parses_integer_values(monkeypatch) -> None:
+    """Integer environment values should be converted safely."""
+    monkeypatch.setenv("TEST_INT", "120")
+
+    assert env_int("TEST_INT", default=30) == 120
+
+
+def test_env_list_parses_csv_values(monkeypatch) -> None:
+    """Comma-separated values should be returned as trimmed items."""
+    monkeypatch.setenv("TEST_LIST", "example.com, api.example.com ,cdn.example.com")
+
+    assert env_list("TEST_LIST") == [
+        "example.com",
+        "api.example.com",
+        "cdn.example.com",
+    ]

--- a/tests/test_production_helpers.py
+++ b/tests/test_production_helpers.py
@@ -3,33 +3,53 @@
 
 from __future__ import annotations
 
+import pytest
+
 from config.settings.production_helpers import env_bool, env_int, env_list
 
 
-def test_env_bool_parses_truthy_values(monkeypatch) -> None:
-    """Truthy string values should evaluate to True."""
-    monkeypatch.setenv("TEST_BOOL", "true")
+@pytest.mark.parametrize(
+    ("raw_value", "default", "expected"),
+    [
+        (None, False, False),
+        (None, True, True),
+        ("1", False, True),
+        ("true", False, True),
+        ("YES", False, True),
+        ("on", False, True),
+        ("0", True, False),
+        ("false", True, False),
+    ],
+)
+def test_env_bool_parses_truthy_falsey_and_default_values(
+    monkeypatch, raw_value: str | None, default: bool, expected: bool
+) -> None:
+    """Boolean helper should support explicit truthy values and fallback defaults."""
+    if raw_value is None:
+        monkeypatch.delenv("TEST_BOOL", raising=False)
+    else:
+        monkeypatch.setenv("TEST_BOOL", raw_value)
 
-    assert env_bool("TEST_BOOL") is True
+    assert env_bool("TEST_BOOL", default=default) is expected
 
 
-def test_env_bool_returns_default_when_missing(monkeypatch) -> None:
-    """Missing values should fall back to the provided default."""
-    monkeypatch.delenv("TEST_BOOL", raising=False)
+def test_env_int_parses_integer_values_and_defaults(monkeypatch) -> None:
+    """Integer helper should return defaults when unset and parse numeric strings."""
+    monkeypatch.delenv("TEST_INT", raising=False)
+    assert env_int("TEST_INT", default=30) == 30
 
-    assert env_bool("TEST_BOOL", default=True) is True
-
-
-def test_env_int_parses_integer_values(monkeypatch) -> None:
-    """Integer environment values should be converted safely."""
     monkeypatch.setenv("TEST_INT", "120")
 
     assert env_int("TEST_INT", default=30) == 120
 
 
-def test_env_list_parses_csv_values(monkeypatch) -> None:
-    """Comma-separated values should be returned as trimmed items."""
-    monkeypatch.setenv("TEST_LIST", "example.com, api.example.com ,cdn.example.com")
+def test_env_list_parses_csv_values_and_defaults(monkeypatch) -> None:
+    """Comma-separated values should be trimmed and preserve default behavior."""
+    monkeypatch.delenv("TEST_LIST", raising=False)
+    assert env_list("TEST_LIST", default=["example.com"]) == ["example.com"]
+    assert env_list("TEST_LIST") == []
+
+    monkeypatch.setenv("TEST_LIST", "example.com, api.example.com ,, cdn.example.com ")
 
     assert env_list("TEST_LIST") == [
         "example.com",

--- a/tests/test_production_settings.py
+++ b/tests/test_production_settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 
+
 def test_production_settings_apply_env_driven_security_and_release_values(monkeypatch) -> None:
     """Production settings should expose the expected hardened env-driven values."""
     monkeypatch.setenv("DJANGO_ALLOWED_HOSTS", "app.example.com,api.example.com")

--- a/tests/test_production_settings.py
+++ b/tests/test_production_settings.py
@@ -1,58 +1,9 @@
-"""Tests for production settings and environment parsing helpers."""
+"""Tests for production settings module behavior."""
 
 from __future__ import annotations
 
 import importlib
 import sys
-
-import pytest
-
-from config.settings.production_helpers import env_bool, env_int, env_list
-
-
-@pytest.mark.parametrize(
-    ("raw_value", "default", "expected"),
-    [
-        (None, False, False),
-        (None, True, True),
-        ("1", False, True),
-        ("true", False, True),
-        ("YES", False, True),
-        ("on", False, True),
-        ("0", True, False),
-        ("false", True, False),
-    ],
-)
-def test_env_bool_parses_truthy_falsey_and_default_values(
-    monkeypatch, raw_value: str | None, default: bool, expected: bool
-) -> None:
-    """Boolean helper should support explicit truthy values and fallback defaults."""
-    if raw_value is None:
-        monkeypatch.delenv("BOOL_SETTING", raising=False)
-    else:
-        monkeypatch.setenv("BOOL_SETTING", raw_value)
-
-    assert env_bool("BOOL_SETTING", default) is expected
-
-
-def test_env_int_parses_integer_values_and_defaults(monkeypatch) -> None:
-    """Integer helper should return defaults when unset and parse numeric strings."""
-    monkeypatch.delenv("INT_SETTING", raising=False)
-    assert env_int("INT_SETTING", 7) == 7
-
-    monkeypatch.setenv("INT_SETTING", "42")
-    assert env_int("INT_SETTING", 7) == 42
-
-
-def test_env_list_splits_comma_separated_values_and_handles_defaults(monkeypatch) -> None:
-    """List helper should trim values and preserve the provided default list."""
-    monkeypatch.delenv("LIST_SETTING", raising=False)
-    assert env_list("LIST_SETTING", ["a", "b"]) == ["a", "b"]
-    assert env_list("LIST_SETTING") == []
-
-    monkeypatch.setenv("LIST_SETTING", " alpha, beta ,, gamma ")
-    assert env_list("LIST_SETTING") == ["alpha", "beta", "gamma"]
-
 
 def test_production_settings_apply_env_driven_security_and_release_values(monkeypatch) -> None:
     """Production settings should expose the expected hardened env-driven values."""


### PR DESCRIPTION
## Summary
Adds reusable environment parsing helpers and separates helper-level coverage from production settings module coverage.

## Changes
- add `config/settings/production_helpers.py` with helpers for boolean, integer, and comma-separated list env values
- add dedicated unit coverage in `tests/test_production_helpers.py`
- keep `tests/test_production_settings.py` focused on production module behavior rather than helper internals
- support production settings parsing without scattering ad hoc env handling across the settings module

## Behavior
- boolean settings can be parsed consistently from common truthy and falsey string values
- integer settings can be parsed from env strings with explicit defaults
- comma-separated env settings can be normalized into trimmed Python lists
- production settings can rely on small, predictable helper functions instead of inline parsing

## Why
- keeps environment parsing pure and easy to unit test
- reduces duplication and inconsistency in production settings logic
- makes production configuration behavior easier to reason about and maintain
- creates a clean separation between helper tests and production settings module tests

## Validation
- `docker compose exec web pytest -q tests/test_production_helpers.py tests/test_production_settings.py`

## Result
- helper parsing behavior is covered directly
- production settings behavior remains covered separately
- focused verification passed with `12 passed`

## Notes
- the helper layer is intentionally Django-independent so it can be tested with simple env patching
- the production settings module continues to consume these helpers while staying focused on exported settings behavior