### PR TITLE
test(security): add landing page header coverage

### DIFF
--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,25 @@
+# path: tests/test_security_headers.py
+"""Integration tests for visible security headers."""
+
+from __future__ import annotations
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+@override_settings(
+    DEBUG=False,
+    SECURE_REFERRER_POLICY="same-origin",
+    SECURE_CONTENT_TYPE_NOSNIFF=True,
+    X_FRAME_OPTIONS="DENY",
+)
+def test_landing_page_includes_expected_security_headers(client) -> None:
+    """A real HTML page should emit the expected security headers."""
+    response = client.get(reverse("landing"))
+
+    assert response.status_code == 200
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "same-origin"
+    assert response.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary
Adds integration coverage for visible security headers on the public landing page.

## Changes
- add `tests/test_security_headers.py`
- request the real `landing` route through Django’s test client
- assert the response includes the expected security-related headers
- use `override_settings` to exercise the header behavior in a focused integration test

## Behavior
- verifies `X-Frame-Options` is set to `DENY`
- verifies `Referrer-Policy` is set to `same-origin`
- verifies `X-Content-Type-Options` is set to `nosniff`
- confirms the headers are present on a real HTML response, not just as settings values

## Why
- protects the public-facing entry page from regressions in visible security headers
- complements production settings work with an end-to-end response check
- validates browser-facing behavior instead of only testing configuration internals

## Validation
- `docker compose exec web pytest -q tests/test_security_headers.py`

## Result
- adds focused integration coverage for the landing page security header contract

## Notes
- the test checks emitted response headers, not full production settings activation
- `override_settings` keeps the test small and isolates the header behavior being verified