### PR TITLE
docs(runbook): add sprint 7 operational walkthrough section

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,6 +2,37 @@
 
 This runbook takes the project from clean clone to a verified local environment and checks the routes, workflows, APIs, ML artifacts, and proof commands that currently match the repository.
 
+## Sprint 7 walkthrough intent
+
+This runbook covers the operational commands and checks needed to run, inspect, and verify ReturnHub after Sprint 7. It is intentionally practical. It assumes a working development or production-like environment and focuses on the tasks an operator, reviewer, or hiring manager might perform during a walkthrough.
+
+Common operator commands:
+
+```bash
+make up
+make ps
+make logs
+make shell
+make migrate
+make test
+make test-cov
+make lint
+make format-check
+make check
+```
+
+Equivalent Docker Compose commands:
+
+```bash
+docker compose up --build -d
+docker compose ps
+docker compose logs -f
+docker compose exec -T web python manage.py migrate
+docker compose exec -T web pytest -q
+docker compose exec -T web python -m ruff check .
+docker compose exec -T web python -m black . --check
+```
+
 ## Scope
 
 This runbook verifies:


### PR DESCRIPTION
## Summary

Adds a Sprint 7 walkthrough section to the runbook to make operational verification easier during a practical project walkthrough.

## Changes

- added a new `Sprint 7 walkthrough intent` section near the top of `RUNBOOK.md`
- included the provided Sprint 7 framing text describing the runbook’s purpose and audience
- added a compact set of `make` commands for common operational tasks
- added equivalent Docker Compose commands for running, inspecting, and verifying the app

## Behavior

The runbook now introduces its practical Sprint 7 purpose earlier and gives readers a faster path to the commands they are most likely to need during a demo, review, or operational walkthrough.

## Why

This makes the runbook more useful for operators, reviewers, and hiring managers by surfacing the most relevant commands and expectations without requiring them to scan the full document first.

## Validation

The added commands were aligned with the repository’s current operational workflow and Makefile targets, including:

- `make up`
- `make ps`
- `make logs`
- `make shell`
- `make migrate`
- `make test`
- `make test-cov`
- `make lint`
- `make format-check`
- `make check`

## Result

The runbook now starts with clearer operational context and a concise command reference for Sprint 7 walkthroughs.

## Notes

- this change updates documentation only
- no application code, CI behavior, or runtime configuration was changed