### PR TITLE
Feat/document ml operations

### DIFF
--- a/docs/ml/operations.md
+++ b/docs/ml/operations.md
@@ -1,0 +1,59 @@
+<!-- path: docs/ml/operations.md -->
+# ReturnHub ML Operations
+
+## Purpose
+
+ReturnHub treats escalation-risk scoring as an operational subsystem with named artefacts, documented inputs, and safe degradation rules. The model is useful only when its training, registry, inference contract, and rollback path are all explicit.
+
+## Artefacts and registry
+
+The model registry file shipped in earlier sprints remains the source of truth for which trained artefact is active. Each scored model release should include:
+
+- model identifier
+- training timestamp
+- feature contract version
+- preprocessing version
+- label threshold notes
+- checksum or hash for the stored artefact
+
+## Inference contract
+
+Inference continues to return the same persisted fields already established in the product contract:
+
+- `score`
+- `label`
+- `reason_codes`
+
+These fields are stored in `RiskScore` and exposed only in the controlled surfaces defined in the earlier sprints. Ops users should see the signal as triage support, not as an automated final decision.
+
+## Retraining process
+
+A retraining run should:
+
+1. use the deterministic synthetic or approved operational-style dataset path
+2. preserve feature ordering and feature contract versioning
+3. record the new artefact in the registry
+4. run prediction-contract and reproducibility tests before activation
+
+Do not activate a new model artefact if reason-code shape, feature ordering, or output fields drift unexpectedly.
+
+## Rollout and rollback
+
+A rollout should update the active registry entry only after tests pass and the artefact checksum is recorded. A rollback should restore the previous active artefact without changing the persistence schema or the API shape.
+
+## Safe degradation
+
+If scoring fails during inference, the application should continue to support the workflow. The case should remain visible, operational actions should remain available, and the UI should present the risk state as unavailable rather than fabricating a value. Logs should capture the failure details for diagnosis.
+
+## Operational checks
+
+Before a demo or release:
+
+- confirm the active registry entry exists
+- confirm prediction-contract tests pass
+- confirm the ops queue and case detail pages still render risk safely
+- confirm absence of evidence still degrades gracefully for evidence-aware features
+
+## Communication to ops users
+
+Explain the risk signal using consistent language. It is a prioritisation aid based on reproducible signals and stored reason codes. It is not a hidden decision engine and it does not replace the workflow controls already present in the case record.

--- a/docs/ml/operations.md
+++ b/docs/ml/operations.md
@@ -3,57 +3,169 @@
 
 ## Purpose
 
-ReturnHub treats escalation-risk scoring as an operational subsystem with named artefacts, documented inputs, and safe degradation rules. The model is useful only when its training, registry, inference contract, and rollback path are all explicit.
+This document describes the ML operations flow that is currently implemented in ReturnHub. It covers the active-model registry, the available dataset and training commands, the runtime scoring path, and the concrete checks that can be used before a demo or release.
 
-## Artefacts and registry
+## Current model setup
 
-The model registry file shipped in earlier sprints remains the source of truth for which trained artefact is active. Each scored model release should include:
+ReturnHub currently uses a logistic-regression baseline for escalation-risk scoring.
 
-- model identifier
-- training timestamp
-- feature contract version
-- preprocessing version
-- label threshold notes
-- checksum or hash for the stored artefact
+The live scoring path depends on:
 
-## Inference contract
+- a committed active-model registry at `ml/registry/model_registry.json`
+- versioned model artifacts under `ml_artifacts/`
+- the shared feature extraction code in `ml/features.py`
+- reason-code generation in `ml/reason_codes.py`
+- risk persistence in `returns/services/risk.py`
 
-Inference continues to return the same persisted fields already established in the product contract:
+Current committed active registry entry:
 
-- `score`
-- `label`
-- `reason_codes`
+```json
+{
+  "active_model": {
+    "contract_version": "return-risk-sprint2-v1",
+    "model_type": "logistic_regression",
+    "reason_code_schema_version": "return-risk-reasons-sprint3-v1",
+    "status": "active",
+    "version": "retrain_baseline-logreg-v1-seed-7-rows-500"
+  }
+}
+```
 
-These fields are stored in `RiskScore` and exposed only in the controlled surfaces defined in the earlier sprints. Ops users should see the signal as triage support, not as an automated final decision.
+Current committed artifacts:
 
-## Retraining process
+- `ml_artifacts/retrain_baseline-logreg-v1-seed-7-rows-500.pkl`
+- `ml_artifacts/retrain_baseline-logreg-v1-seed-7-rows-500.json`
 
-A retraining run should:
+## Registry contract
 
-1. use the deterministic synthetic or approved operational-style dataset path
-2. preserve feature ordering and feature contract versioning
-3. record the new artefact in the registry
-4. run prediction-contract and reproducibility tests before activation
+The registry stores one active model entry.
 
-Do not activate a new model artefact if reason-code shape, feature ordering, or output fields drift unexpectedly.
+The current registry shape is defined by:
 
-## Rollout and rollback
+- `ml/services/model_registry.py`
+- `ml/registry.py`
 
-A rollout should update the active registry entry only after tests pass and the artefact checksum is recorded. A rollback should restore the previous active artefact without changing the persistence schema or the API shape.
+Current fields:
+
+- `version`
+- `model_type`
+- `contract_version`
+- `reason_code_schema_version`
+- `status`
+
+The registry is updated by:
+
+- `python manage.py train_escalation_model --seed 7 --size 500`
+- `python manage.py retrain_baseline_model --seed 7 --rows 500`
+
+`train_escalation_model` writes the active entry directly after baseline training.
+
+`retrain_baseline_model` uses the current wrapper flow in `ml/training/train.py` and then writes the active entry.
+
+## Dataset and training commands
+
+Current dataset-generation commands:
+
+- `python manage.py generate_risk_dataset --seed 7 --size 250`
+- `python manage.py generate_training_dataset --seed 7 --rows 300`
+
+Default dataset outputs:
+
+- `artifacts/ml/synthetic_return_risk_dataset.csv`
+- `artifacts/ml/evidence_aware_training_dataset.csv`
+
+Current training commands:
+
+- `python manage.py train_escalation_model --seed 7 --size 500`
+- `python manage.py retrain_baseline_model --seed 7 --rows 500`
+
+Training artifacts are written under:
+
+- `ml_artifacts/`
+
+Each trained version writes:
+
+- `<model_version>.pkl`
+- `<model_version>.json`
+
+## Runtime scoring path
+
+The current artifact-backed scoring flow is:
+
+1. `returns/services/risk.py` calls `score_case_and_persist(...)`.
+2. That service tries `ml/services/scoring.py`.
+3. `ml/services/scoring.py` loads the active registry entry from `ml/registry/model_registry.json`.
+4. It resolves the matching `.pkl` and `.json` files under `ml_artifacts/`.
+5. It loads the model artifact and metadata.
+6. It extracts case features with `ml.features.extract_case_features(...)`.
+7. It runs `predict_proba(...)` and converts the probability into:
+   - persisted `score`
+   - operational `label`
+   - structured `reason_codes`
+8. `returns/services/risk.py` persists the result to `RiskScore` and writes a `risk_scored` case event.
+
+Current label thresholds in `ml/services/scoring.py`:
+
+- `>= 0.75` -> `high`
+- `>= 0.45` -> `medium`
+- otherwise -> `low`
+
+The artifact metadata must include `feature_contract_hash`. If it is missing, artifact-backed scoring is rejected.
 
 ## Safe degradation
 
-If scoring fails during inference, the application should continue to support the workflow. The case should remain visible, operational actions should remain available, and the UI should present the risk state as unavailable rather than fabricating a value. Logs should capture the failure details for diagnosis.
+If artifact-backed scoring is unavailable, ReturnHub currently falls back to the placeholder scorer in `ml/scoring.py`.
+
+This fallback is implemented in:
+
+- `returns/services/risk.py`
+- `returns/services/risk_scoring.py`
+
+In the main returns workflow, the active path is `returns/services/risk.py`.
+
+The fallback behavior is:
+
+- the case workflow continues
+- a score is still produced from extracted features
+- the risk record is persisted
+- a warning is logged indicating that placeholder scoring was used
+
+This means the current system does not surface risk as unavailable. It degrades to placeholder scoring instead.
+
+## Rescoring triggers
+
+The current returns workflow triggers scoring on:
+
+- case creation in `returns/services/cases.py`
+- status update in `returns/services/cases.py`
+- document upload in `returns/services/documents.py`
+
+These flows call `returns/services/risk.py:score_case_and_persist(...)`.
 
 ## Operational checks
 
-Before a demo or release:
+Before a demo or release, the current project supports these concrete checks:
 
-- confirm the active registry entry exists
-- confirm prediction-contract tests pass
-- confirm the ops queue and case detail pages still render risk safely
-- confirm absence of evidence still degrades gracefully for evidence-aware features
+- confirm `ml/registry/model_registry.json` contains an active model entry
+- confirm the matching `.pkl` and `.json` files exist under `ml_artifacts/`
+- run the registry tests in `tests/test_model_registry.py`
+- run the artifact scoring and fallback tests in `tests/test_artifact_scoring.py`
+- run the training and command tests in:
+  - `tests/test_baseline_training.py`
+  - `tests/test_ml_training.py`
+  - `tests/test_ml_management_commands.py`
+  - `tests/test_train_escalation_model_command.py`
+  - `tests/test_risk_dataset_generation.py`
+- verify the ops queue and case detail surfaces still render risk information safely
 
-## Communication to ops users
+## Boundaries and current limitations
 
-Explain the risk signal using consistent language. It is a prioritisation aid based on reproducible signals and stored reason codes. It is not a hidden decision engine and it does not replace the workflow controls already present in the case record.
+This document describes what is implemented now.
+
+The current implementation does not add extra operational metadata such as:
+
+- artifact checksum fields in the registry
+- preprocessing-version fields in the registry
+- a dedicated rollback management command
+
+Rollback today is a manual operational action: restore a previous valid registry entry and ensure the matching artifacts exist under `ml_artifacts/`.


### PR DESCRIPTION
## Summary
Adds a project-aligned ML operations guide for ReturnHub that documents the current registry, training, scoring, fallback, and pre-release verification flow.

## Changes
- added `docs/ml/operations.md`
- documented the active-model registry shape and the currently committed active model version
- documented the dataset-generation and training commands that exist in the repo today
- described the current artifact-backed runtime scoring flow
- documented the implemented fallback behavior to placeholder scoring when active artifacts are unavailable
- documented the current rescoring triggers across the returns workflow
- added concrete operational checks and test files to review before demos or releases
- clarified current limitations, including the absence of checksum fields, preprocessing metadata in the registry, and a dedicated rollback command

## Behavior
- gives the team a concrete ML operations reference that matches the implementation in the current branch
- makes the scoring path, artifact expectations, and fallback behavior easier to understand during demos, reviews, and maintenance work
- reduces ambiguity around what is actually implemented versus what might be planned later

## Why
- the previous operations language was broader and more target-state oriented than the current codebase
- the project already has a real registry, training flow, artifact-backed scorer, and tested fallback path that should be documented directly
- an operations guide is only useful if it describes the current system accurately enough for support, review, and release work

## Validation
- aligned the document with the current ML commands in:
  - `ml/management/commands/generate_risk_dataset.py`
  - `ml/management/commands/generate_training_dataset.py`
  - `ml/management/commands/train_escalation_model.py`
  - `ml/management/commands/retrain_baseline_model.py`
- aligned the registry section with:
  - `ml/services/model_registry.py`
  - `ml/registry.py`
  - `ml/registry/model_registry.json`
- aligned the scoring and fallback description with:
  - `ml/services/scoring.py`
  - `returns/services/risk.py`
  - `returns/services/risk_scoring.py`
- aligned the operational checks with existing ML and scoring test coverage in the repo

## Result
- ReturnHub now has an ML operations document that accurately reflects the current registry and scoring architecture
- reviewers and maintainers can trace the active model flow from training to runtime persistence
- demo and release preparation now has a clearer ML-specific reference point

## Notes
- this is a documentation-only change
- no runtime scoring, registry, training, or persistence logic was changed by this PR